### PR TITLE
Advising `treesit-install-language-grammar`

### DIFF
--- a/README.org
+++ b/README.org
@@ -110,16 +110,6 @@ remap, simply include a line like this before calling =treesit-auto-apply-remap=
   (add-to-list 'treesit-auto-fallback-alist '(bash-ts-mode . sh-mode))
 #+end_src
 
-** Refresh major mode remaps after installing a grammar
-If you want =treesit-auto-apply-remap= to re-run after installing a grammar with
-=treesit-install-language-grammar=, try advising the function with something like
-this:
-
-#+begin_src emacs-lisp
-  (advice-add 'treesit-install-language-grammar
-              :after (lambda (&rest _r) (treesit-auto-apply-remap)))
-#+end_src
-
 ** Keep track of your hooks
 This package does not modify any of your major mode hooks.  That is, if you have
 functions in =python-mode-hook=, but not in =python-ts-mode-hook=, then your hook
@@ -140,7 +130,5 @@ This is how I configure =treesit-auto= for my own personal use.
       :config
       (add-to-list 'treesit-auto-fallback-alist '(bash-ts-mode . sh-mode))
       (setq treesit-auto-install 'prompt)
-      (advice-add 'treesit-install-language-grammar
-		  :after (lambda (&rest _r) (treesit-auto-apply-remap)))
       (global-treesit-auto-mode))
 #+end_src

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -171,6 +171,10 @@ the grammar it will then re-enable the current major-mode."
     (add-to-list 'treesit-language-source-alist elt t))
   (mapcar #'treesit-auto--remap-language-source treesit-language-source-alist))
 
+(defun treesit-auto--install-language-grammar-wrapper (&rest _r)
+  "Run `treesit-auto-apply-remap' after `treesit-install-language-grammar'."
+  (treesit-auto-apply-remap))
+
 ;;;###autoload
 (define-minor-mode global-treesit-auto-mode
   "Toggle `global-treesit-auto-mode'."
@@ -179,8 +183,11 @@ the grammar it will then re-enable the current major-mode."
   (if global-treesit-auto-mode
       (progn
         (add-hook 'prog-mode-hook #'treesit-auto--maybe-install-grammar)
+        (advice-add 'treesit-install-language-grammar
+		:after #'treesit-auto--install-language-grammar-wrapper)
         (treesit-auto-apply-remap))
-    (remove-hook 'prog-mode-hook #'treesit-auto--maybe-install-grammar)))
+    (remove-hook 'prog-mode-hook #'treesit-auto--maybe-install-grammar)
+    (advice-remove 'treesit-install-language-grammar #'treesit-auto--install-language-grammar-wrapper)))
 
 (provide 'treesit-auto)
 ;;; treesit-auto.el ends here


### PR DESCRIPTION
Removes the need for users to configure this advice, instead opting to add/remove it through `global-treesit-auto-mode`.