### PR TITLE
Automatically install and enable tree-sitter modes when visiting its corresponding original mode

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -134,9 +134,7 @@ downloading and installing the grammar."
   (mapcar 'treesit-auto--get-assoc (treesit-auto--available-modes)))
 
 (defun treesit-auto--lang (mode)
-  "Determine the tree-sitter language symbol for MODE.
-
-For both `python-mode' and `python-ts-mode', this is `python'."
+  "Determine the tree-sitter language symbol for MODE."
   (let* ((available (treesit-auto--available-alist))
          (ts-mode (or (car (rassq mode available))
                       (car (assq mode available))))

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -109,6 +109,13 @@ downloading and installing the grammar."
                             (no-internals (not (string-match "--" name))))
                   (push name result))))
     result))
+;; TODO Now, if any of these `-ts-mode's appear as a car in
+;; `major-mode-remap-alist', that means we're missing its grammar, and when
+;; visiting the cdr, should check the auto-install variable
+;;
+;;  ((yaml-ts-mode . yaml-mode)  ; DO check for auto install on next yaml-mode buffer
+;;   ...
+;;   (go-mode . go-ts-mode)      ; DON'T check for auto install (already have it)
 
 (defun treesit-auto--remap-language-source (language-source)
   "Determine mode for LANGUAGE-SOURCE.

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -115,7 +115,11 @@ downloading and installing the grammar."
 ;;
 ;;  ((yaml-ts-mode . yaml-mode)  ; DO check for auto install on next yaml-mode buffer
 ;;   ...
-;;   (go-mode . go-ts-mode)      ; DON'T check for auto install (already have it)
+;;   (go-mode . go-ts-mode))     ; DON'T check for auto install (already have it)
+;;
+;; This behavior should be patched into `treesit-auto--maybe-install-grammar',
+;; which should also retain its current behavior of auto-installing upon
+;; activation of a missing-grammar `-ts-mode'.
 
 (defun treesit-auto--remap-language-source (language-source)
   "Determine mode for LANGUAGE-SOURCE.

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -117,7 +117,6 @@ downloading and installing the grammar."
 
 (defun treesit-auto--get-assoc (ts-name)
   "Build a cons like (`name-ts-mode' . `name-mode') based on TS-NAME."
-  ;; TODO if ts-name in fallback alist, use lookup, otherwise string manipulate
   (or (assq ts-name treesit-auto-fallback-alist)
       (when-let (fallback-assoc (rassq ts-name treesit-auto-fallback-alist))
         ;; Reverse order so that ts-mode comes first

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -123,6 +123,16 @@ downloading and installing the grammar."
         `(,(cdr fallback-assoc) . ,(car fallback-assoc)))
       `(,ts-name .  ,(treesit-auto--string-convert-ts-name (symbol-name ts-name)))))
 
+(defun treesit-auto--available-alist ()
+  "Build an alist of available tree-sitter modes paired with original modes."
+  (mapcar 'treesit-auto--get-assoc (treesit-auto--available-modes)))
+
+(defun treesit-auto--lang (mode)
+  "Determine the tree-sitter language symbol for MODE.
+For both `python-mode' and `python-ts-mode', this is 'python."
+  ;; TODO
+  )
+
 (defun treesit-auto--remap-language-source (language-source)
   "Determine mode for LANGUAGE-SOURCE.
 If the grammar is installed, remap the base mode to its

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -155,7 +155,7 @@ Returns `non-nil' if install was completed without error."
                  (yes-or-no-p (format "Tree-sitter grammar for %s is missing.  Would you like to install it from %s? "
                                       (symbol-name lang)
                                       (car repo))))
-                (t) nil)
+                (t))
       (message "Installing the tree-sitter grammar for %s" lang)
       ;; treesit-install-language-grammar will return nil if the
       ;; operation succeeded and 't if a warning was sent to the

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -110,20 +110,6 @@ downloading and installing the grammar."
                             (no-internals (not (string-match "--" name))))
                   (push (intern name) result))))
     result))
-;; TODO Now, if any of these `-ts-mode's appear as a car in
-;; `major-mode-remap-alist', that means we're missing its grammar, and when
-;; visiting the cdr, should check the auto-install variable
-;;
-;;  ((yaml-ts-mode . yaml-mode)  ; DO check for auto install on next yaml-mode buffer
-;;   ...
-;;   (go-mode . go-ts-mode))     ; DON'T check for auto install (already have it)
-;;
-;; This behavior should be patched into `treesit-auto--maybe-install-grammar',
-;; which should also retain its current behavior of auto-installing upon
-;; activation of a missing-grammar `-ts-mode', since it is not a guarantee that
-;; every missing-grammar `-ts-mode' appears in this alist.  For example, if
-;; `go-mode' is not installed, `go-ts-mode' will not be in the alist unless it
-;; is added by the user.
 
 (defun treesit-auto--string-convert-ts-name (name-ts-mode)
   "Convert NAME-TS-MODE, a string, to `name-mode', a symbol."
@@ -178,9 +164,6 @@ Returns `non-nil' if install was completed without error."
       ;; work in the future.
       (not (treesit-install-language-grammar lang)))))
 
-
-;; TODO a general utility for swapping between `name-mode' and `name-ts-mode',
-;; using all available information would be useful here.
 (defun treesit-auto--maybe-install-grammar ()
   "Try to install the grammar matching the current major-mode.
 

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -194,9 +194,7 @@ the grammar it will then re-enable the current major-mode."
                                   "\\(.*\\)-ts-mode$" "\\1"
                                   mode))))
               ((not (treesit-ready-p lang 't)))
-              ((and
-                treesit-auto-install
-                (treesit-auto--prompt-to-install-package lang))))
+              ((treesit-auto--prompt-to-install-package lang)))
     ;; We need to rerun the current major mode after a successful
     ;; install because we only hook into after the major-mode has
     ;; finished setup. So, if the install fails it will fail to load

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -119,7 +119,10 @@ downloading and installing the grammar."
 ;;
 ;; This behavior should be patched into `treesit-auto--maybe-install-grammar',
 ;; which should also retain its current behavior of auto-installing upon
-;; activation of a missing-grammar `-ts-mode'.
+;; activation of a missing-grammar `-ts-mode', since it is not a guarantee that
+;; every missing-grammar `-ts-mode' appears in this alist.  For example, if
+;; `go-mode' is not installed, `go-ts-mode' will not be in the alist unless it
+;; is added by the user.
 
 (defun treesit-auto--remap-language-source (language-source)
   "Determine mode for LANGUAGE-SOURCE.
@@ -162,6 +165,9 @@ Returns `non-nil' if install was completed without error."
       ;; work in the future.
       (not (treesit-install-language-grammar lang)))))
 
+
+;; TODO a general utility for swapping between `name-mode' and `name-ts-mode',
+;; using all available information would be useful here.
 (defun treesit-auto--maybe-install-grammar ()
   "Try to install the grammar matching the current major-mode.
 

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -192,6 +192,10 @@ the grammar it will then re-enable the current major-mode."
     (add-to-list 'treesit-language-source-alist elt t))
   (mapcar #'treesit-auto--remap-language-source treesit-language-source-alist))
 
+(defun treesit-auto--install-language-grammar-wrapper (&rest _r)
+  "Run `treesit-auto-apply-remap' after `treesit-install-language-grammar'."
+  (treesit-auto-apply-remap))
+
 ;;;###autoload
 (define-minor-mode global-treesit-auto-mode
   "Toggle `global-treesit-auto-mode'."
@@ -200,8 +204,11 @@ the grammar it will then re-enable the current major-mode."
   (if global-treesit-auto-mode
       (progn
         (add-hook 'prog-mode-hook #'treesit-auto--maybe-install-grammar)
+        (advice-add 'treesit-install-language-grammar
+		:after #'treesit-auto--install-language-grammar-wrapper)
         (treesit-auto-apply-remap))
-    (remove-hook 'prog-mode-hook #'treesit-auto--maybe-install-grammar)))
+    (remove-hook 'prog-mode-hook #'treesit-auto--maybe-install-grammar)
+    (advice-remove 'treesit-install-language-grammar #'treesit-auto--install-language-grammar-wrapper)))
 
 (provide 'treesit-auto)
 ;;; treesit-auto.el ends here

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -197,16 +197,12 @@ Returns `non-nil' if install was completed without error."
 If the tree-sitter grammar is missing for the current major mode,
 it will prompt the user if they want to install it from the
 currently registered repository.  If the user chooses to install
-the grammar it will then re-enable the current major-mode."
-  (when-let* (((not (treesit-auto--ready-p major-mode)))
+the grammar it will then switch to the tree-sitter powered
+version of the current major-mode."
+  (when-let* ((not-ready (not (treesit-auto--ready-p major-mode)))
               (lang (treesit-auto--lang major-mode))
-              ((treesit-auto--prompt-to-install-package lang)))
-    ;; We need to rerun the current major mode after a successful
-    ;; install because we only hook into after the major-mode has
-    ;; finished setup. So, if the install fails it will fail to load
-    ;; or fallback to the mode defined in the remap-alist. But, if it
-    ;; succeeds we assume the user wants to use the `ts-mode'.
-    (funcall major-mode)))
+              (install-success (treesit-auto--prompt-to-install-package lang)))
+    (funcall (intern (concat (symbol-name lang) "-ts-mode")))))
 
 ;;;###autoload
 (defun treesit-auto-apply-remap ()

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -100,6 +100,16 @@ downloading and installing the grammar."
     (yaml "https://github.com/ikatyang/tree-sitter-yaml"))
   "Default repository URLs for `treesit-install-language-grammar'.")
 
+(defun treesit-auto--install-langs ()
+  "Build a list of all modes ending with `-ts-mode' as strings."
+  (let ((result '()))
+    (mapatoms (lambda (elt)
+                (when-let* ((name (symbol-name elt))
+                            (match (string-match "-ts-mode$" name))
+                            (no-internals (not (string-match "--" name))))
+                  (push name result))))
+    result))
+
 (defun treesit-auto--remap-language-source (language-source)
   "Determine mode for LANGUAGE-SOURCE.
 If the grammar is installed, remap the base mode to its


### PR DESCRIPTION
As discussed in #8, I really like having Emacs prompt me when a tree-sitter version of a language exists, but isn't installed yet.  This is in contrast to the behavior we have now, which is to only prompt for installation if the _tree-sitter_ mode is activated.