### PR TITLE
Redo some parts to account for name/lang differences

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 0.3.2
+current_version = 0.3.3
 
 [bumpversion:file:treesit-auto.el]

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -5,7 +5,7 @@
 ;; Author: Robb Enzmann <robbenzmann@gmail.com>
 ;; Keywords: treesitter auto automatic major mode fallback convenience
 ;; URL: https://github.com/renzmann/treesit-auto.git
-;; Version: 0.3.2
+;; Version: 0.3.3
 ;; Package-Requires: ((emacs "29.0"))
 
 ;; This file is not part of GNU Emacs.

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -134,13 +134,17 @@ prefix.  Each entry should have the form (PREFIX . LANG).")
   "Convert NAME-TS-MODE, a string, to `name-mode', a symbol."
   (intern (concat (treesit-auto--extract-name name-ts-mode) "-mode")))
 
+;; FIXME `ts-name' is a confusing variable name.  Change to name-ts-mode
 (defun treesit-auto--get-assoc (ts-name)
   "Build a cons like (`name-ts-mode' . `name-mode') based on TS-NAME."
   (or (assq ts-name treesit-auto-fallback-alist)
       (when-let (fallback-assoc (rassq ts-name treesit-auto-fallback-alist))
         ;; Reverse order so that ts-mode comes first
         `(,(cdr fallback-assoc) . ,(car fallback-assoc)))
-      `(,ts-name .  ,(treesit-auto--string-convert-ts-name (symbol-name ts-name)))))
+      (when-let ((auto-name (treesit-auto--string-convert-ts-name (symbol-name ts-name)))
+                 ((fboundp auto-name)))
+        `(,ts-name .  ,auto-name))
+      `(,ts-name . nil)))
 
 (defvar treesit-auto--available-alist
   (mapcar 'treesit-auto--get-assoc (treesit-auto--available-modes))


### PR DESCRIPTION
Still need to find out why .go and .rs files don't trigger rust-ts-mode and go-ts-mode now.