### PR TITLE
New feature: install all missing grammars at once

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 0.3.3
+current_version = 0.4.0
 
 [bumpversion:file:treesit-auto.el]

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -77,17 +77,17 @@ downloading and installing the grammar."
   '((bash "https://github.com/tree-sitter/tree-sitter-bash")
     (bibtex "https://github.com/latex-lsp/tree-sitter-bibtex")
     (c "https://github.com/tree-sitter/tree-sitter-c")
+    (c-sharp "https://github.com/tree-sitter/tree-sitter-c-sharp")
     (clojure "https://github.com/sogaiu/tree-sitter-clojure")
     (cmake "https://github.com/uyha/tree-sitter-cmake")
-    (common-lisp "https://github.com/theHamsta/tree-sitter-commonlisp")
+    (commonlisp "https://github.com/theHamsta/tree-sitter-commonlisp")
     (cpp "https://github.com/tree-sitter/tree-sitter-cpp")
     (css "https://github.com/tree-sitter/tree-sitter-css")
     (css-in-js "https://github.com/orzechowskid/tree-sitter-css-in-js")
-    (csharp "https://github.com/tree-sitter/tree-sitter-c-sharp")
     (dockerfile "https://github.com/camdencheek/tree-sitter-dockerfile")
     (elisp "https://github.com/Wilfred/tree-sitter-elisp")
     (go "https://github.com/tree-sitter/tree-sitter-go")
-    (go-mod "https://github.com/camdencheek/tree-sitter-go-mod")
+    (gomod "https://github.com/camdencheek/tree-sitter-go-mod")
     (html "https://github.com/tree-sitter/tree-sitter-html")
     (java "https://github.com/tree-sitter/tree-sitter-java")
     (julia "https://github.com/tree-sitter/tree-sitter-julia")
@@ -120,7 +120,10 @@ downloading and installing the grammar."
 
 (defvar treesit-auto--name-lang-alist
   '((c++ . cpp)
-    (js . javascript))
+    (js . javascript)
+    (common-lisp . commonlisp)
+    (csharp . c-sharp)
+    (go-mod . gomod))
   "Alist defining the `lang' symbol for a given tree-sitter mode.
 
 This is for the special case of when the `lang' passed
@@ -236,8 +239,7 @@ version of the current major-mode."
 For example, to prevent installing the `rust-ts-mode' grammar,
 add \\='rust to this list."
   :type '(list (symbol))
-  :group 'treesit
-  )
+  :group 'treesit)
 
 ;;;###autoload
 (defun tresit-auto-install-all ()
@@ -246,13 +248,13 @@ add \\='rust to this list."
 Individual grammars can be opted out of by adding them to
 `treesit-auto-opt-out-list'."
   (interactive)
-  (let* ((to-install (seq-filter
-                      (lambda (lang) (not (treesit-auto--ready-p lang)))
-                      (cl-set-difference
-                       (mapcar 'car treesit-auto--language-source-alist)
-                       treesit-auto-opt-out-list)))
-         (prompt (format "The following tree-sitter grammars are missing:\n%s\n"
-                         (mapconcat 'symbol-name to-install "\n"))))
+  (when-let* ((to-install (seq-filter
+                           (lambda (lang) (not (treesit-auto--ready-p lang)))
+                           (cl-set-difference
+                            (mapcar 'car treesit-auto--language-source-alist)
+                            treesit-auto-opt-out-list)))
+              (prompt (format "The following tree-sitter grammars are missing:\n%s\n"
+                              (mapconcat 'symbol-name to-install "\n"))))
     (with-output-to-temp-buffer "*Treesit-auto install candidates*"
       (princ prompt))
     (when (y-or-n-p "Install missing grammars? ")

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -5,7 +5,7 @@
 ;; Author: Robb Enzmann <robbenzmann@gmail.com>
 ;; Keywords: treesitter auto automatic major mode fallback convenience
 ;; URL: https://github.com/renzmann/treesit-auto.git
-;; Version: 0.3.3
+;; Version: 0.4.0
 ;; Package-Requires: ((emacs "29.0"))
 
 ;; This file is not part of GNU Emacs.

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -206,7 +206,7 @@ Returns `non-nil' if install was completed without error."
   (let ((repo (alist-get lang treesit-language-source-alist)))
     (when (cond ((eq t treesit-auto-install) t)
                 ((eq 'prompt treesit-auto-install)
-                 (yes-or-no-p (format "Tree-sitter grammar for %s is missing.  Would you like to install it from %s? "
+                 (y-or-n-p (format "Tree-sitter grammar for %s is missing.  Would you like to install it from %s? "
                                       (symbol-name (treesit-auto--lang-to-name lang))
                                       (car repo)))))
       (message "Installing the tree-sitter grammar for %s" lang)
@@ -251,12 +251,11 @@ Individual grammars can be opted out of by adding them to
                       (cl-set-difference
                        (mapcar 'car treesit-auto--language-source-alist)
                        treesit-auto-opt-out-list)))
-         (prompt (format "The following tree-sitter grammars are missing.  Would you like to install them?\n%s\n"
+         (prompt (format "The following tree-sitter grammars are missing:\n%s\n"
                          (mapconcat 'symbol-name to-install "\n"))))
-    ;; FIXME: works, but doesn't display the whole message if
-    ;; `max-mini-window-height' is too small.  Need to find a better
-    ;; display/prompt system.
-    (when (yes-or-no-p prompt)
+    (with-output-to-temp-buffer "*Treesit-auto install candidates*"
+      (princ prompt))
+    (when (y-or-n-p "Install missing grammars? ")
       (mapcar 'treesit-install-language-grammar to-install))))
 
 ;;;###autoload

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -255,10 +255,14 @@ Individual grammars can be opted out of by adding them to
                             treesit-auto-opt-out-list)))
               (prompt (format "The following tree-sitter grammars are missing:\n%s\n"
                               (mapconcat 'symbol-name to-install "\n"))))
-    (with-output-to-temp-buffer "*Treesit-auto install candidates*"
-      (princ prompt))
-    (when (y-or-n-p "Install missing grammars? ")
-      (mapcar 'treesit-install-language-grammar to-install))))
+    ;; TODO QOL - it would be nice if this messaged what was installed or at
+    ;; least mentioned that nothing was installed if skipped.
+    (unless (eq treesit-auto-install t) ; Quiet mode is off
+      ;; TODO de-couple this?  Allow for prefix to prompt?
+      (with-output-to-temp-buffer "*Treesit-auto install candidates*"
+        (princ prompt))
+      (y-or-n-p "Install missing grammars? "))
+    (mapcar 'treesit-install-language-grammar to-install)))
 
 ;;;###autoload
 (defun treesit-auto-apply-remap ()


### PR DESCRIPTION
This provides a new interactive function `M-x treesit-auto-install-all`, which checks for available grammars in `treesit-language-source-alist` and optionally prompts y/n before installing.