### PR TITLE
v0.5: Breaking changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing new recipes
+
+Each language's behavior for upgrade, fallback, and installation are defined by
+a recipe in `treesit-auto-recipe-list`.  Here is an example entry for
+JavaScript:
+
+```elisp
+    ,(make-treesit-auto-recipe
+      :lang 'javascript
+      :ts-mode 'js-ts-mode
+      :remap '(js-mode javascript-mode js2-mode)
+      :url "https://github.com/tree-sitter/tree-sitter-javascript"
+      :revision "master"
+      :source-dir "src")
+```
+
+1. `:lang` should *exactly* match the grammar name in the source repository's
+   `grammar.json`
+2. `:ts-mode` must be a single quoted symbol that is the tree-sitter mode Emacs
+   should use for this grammar
+3. `:remap` is either a quoted symbol or quoted list of symbols that are modes
+   that should attempt to "switch up" to the tree-sitter major mode.  When the
+   tree-sitter grammar isn't available, these modes are tried *in order* as
+   fallback modes
+4. `:url` must specify the grammar's source repository.  Many are already listed
+   on the [tree-sitter GitHub](https://github.com/tree-sitter)
+5. `:revision` and `:source-dir` are optional, but may be required if the
+   `scanner.c` file is not found under the default directory or on the default
+   branch
+6. `:cc` and `:c++` should be left unspecified, as they are reserved for user
+   customization
+
+
+When submitting a pull request for a new recipe, use the title `New recipe:
+<grammar name>`, and ensure that the patch consists only of the net-new recipe
+lines, in the correct alphabetical position within `treesit-auto-recipe-list`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,6 @@ JavaScript:
 6. `:cc` and `:c++` should be left unspecified, as they are reserved for user
    customization
 
-
 When submitting a pull request for a new recipe, use the title `New recipe:
 <grammar name>`, and ensure that the patch consists only of the net-new recipe
 lines, in the correct alphabetical position within `treesit-auto-recipe-list`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,8 @@ JavaScript:
 ```
 
 1. `:lang` should *exactly* match the grammar name in the source repository's
-   `grammar.json`
+   `grammar.js`.  Look for a line [like
+   this](https://github.com/tree-sitter/tree-sitter-python/blob/9e53981ec31b789ee26162ea335de71f02186003/grammar.js#L28)
 2. `:ts-mode` must be a single quoted symbol that is the tree-sitter mode Emacs
    should use for this grammar
 3. `:remap` is either a quoted symbol or quoted list of symbols that are modes

--- a/README.org
+++ b/README.org
@@ -15,7 +15,6 @@ Each of these behaviors are configurable and documented under the
 + Automatically switch to =<name>-ts-mode= when the grammar for =<name>= is installed
 + Stick with =<name>-mode= if the grammar isn't installed
 + (Optional) automatically install a grammar before opening a compatible file
-  type
 
 There is also a convenience function =M-x treesit-auto-install-all=, which will
 install all of the maintained and compatible grammars.
@@ -44,8 +43,8 @@ Then, in your Emacs configuration file (=~/.emacs.d/init.el=),
     (global-treesit-auto-mode))
 #+end_src
 
-There are some nifty things you might want to enable, though, which are covered
-in the "Configuration" section below.
+For most users, this will be enough.  There are some nifty things you might want
+to enable, though, which are covered in the "Configuration" section below.
 
 * What this package does
 Emacs 29, while featuring =treesit.el= and a convenient
@@ -78,29 +77,29 @@ the grammar installed, I wind up with an installed grammar and a buffer using
 Otherwise, when ~treesit-auto-install~ is nil, it will try to fall back to
 another major mode as described in the following two rules.
 
-*3. If the grammar is NOT installed, and the user has specified a fallback*
+*3. If the grammar is NOT installed, and a fallback is specified*
 
-The customizable variable =treesit-auto-fallback-alist= lets you pick the fallback
-modes by name.  For instance, if we apply this:
+Most languages will have a fallback mode specified, such as =python-ts-mode=
+falling back to =python-mode=, if the grammar is not installed.  If you ever need
+to double-check what that fallback will be, you can double check what's in the
+recipe for that language like this:
 
-#+begin_src emacs-lisp
-  (add-to-list 'treesit-auto-fallback-alist '(toml-ts-mode . conf-toml-mode))
-#+end_src
+#+begin_example
+(treesit-auto-recipe-remap (alist-get 'python treesit-auto-lang-recipe-alist))
+    ⇒ python-mode
+#+end_example
 
-Then, when the TOML grammar is missing, Emacs will use =conf-toml-mode=, instead
-of trying to fall back to =toml-mode=.
+See "Configuration/Configuring behavior for a specific language" in case you
+would like to specify different fallback modes than the default.
 
 *4. All other cases...*
 
 This is the most general case, where the grammar is not installed,
-~treesit-auto-install~ is nil, no fallback mode is specified in
-~treesit-auto-fallback-alist~, and an similarly named base mode exists.  Here,
-~treesit-auto~ will switch to the non-tree-sitter major mode sharing a common
-prefix.
-
-For example, if the Go tree-sitter grammar is not installed, but we have
-installed [[https://github.com/dominikh/go-mode.el][go-mode]], then Emacs will use that instead of =go-ts-mode=, since they
-share the same =go-= prefix.
+~treesit-auto-install~ is nil, and no fallback mode is specified in the language
+recipe present on =treesit-auto-recipe-list=.  In this case, we still gain the
+benefit of quickly installing grammars through =treesit-install-language-grammar=
+without having the build the recipe interactively, but =treesit-auto= will make no
+attempt to switch away from the tree-sitter mode.
 
 * Configuration
 If you have modified =treesit-language-source-alist= through =setq=, then it is
@@ -127,26 +126,64 @@ equivalent) under =~/.emacs.d/tree-sitter= (or anywhere else in
 will generate this prompt:
 
 #+begin_example
-  Tree-sitter grammar for python is missing.  Would you like to install it from https://github.com/tree-sitter/tree-sitter-python? (yes/no)
+  Tree-sitter grammar for python is missing.  Would you like to install it from https://github.com/tree-sitter/tree-sitter-python? (y or n)
 #+end_example
 
-Responding with "yes" will use =treesit-install-langauge-grammar= to go fetch and
+Responding with "yes" will use =treesit-install-language-grammar= to go fetch and
 compile the missing grammar.
 
 The other function that respects this variable is =treesit-auto-install-all=.
 When =treesit-auto-install= is t, using =M-x treesit-auto-install-all= will skip all
 prompts.  Otherwise, it will ask before attempting the installation.
 
-** When major mode names don't match
-Not all default major modes make sense to bump up to a similar tree-sitter mode.
-For example, when /I/ open a =.sh= file, my intent is nearly always to use it with
-Bash.  This is not the case for everyone, though, so by default this package
-will not replace =sh-mode= with =bash-ts-mode=.  If you do want such a remap, simply
-include a line like this before calling =treesit-auto-apply-remap=:
+** Configuring behavior for a specific language
+The variable =treesit-auto-recipe-list= keeps track of all the language "recipes."
+These control how =treesit-auto= decides which modes to upgrade/downgrade to/from,
+where the source code of the language grammar is hosted, and which C/C++
+compiler to use.  Each recipe can take these arguments:
 
-#+begin_src emacs-lisp
-  (add-to-list 'treesit-auto-fallback-alist '(bash-ts-mode . sh-mode))
+#+begin_example
+:lang
+:ts-mode
+:remap
+:url
+:revision
+:source-dir
+:cc
+:c++
+#+end_example
+
+To create a recipe, use =make-treesit-auto-recipe=:
+
+#+begin_src elisp
+  (setq my-js-tsauto-config
+	(make-treesit-auto-recipe
+	 :lang 'javascript
+	 :ts-mode 'js-ts-mode
+	 :remap '(js2-mode js-mode javascript-mode)
+	 :url "https://github.com/tree-sitter/tree-sitter-javascript"
+	 :revision "master"
+	 :source-dir "src"))
+
+  (add-to-list 'treesit-auto-recipe-list my-js-tsauto-config)
 #+end_src
+
+Here, we've specified that the tree-sitter compiler will be creating a file
+named =libtree-sitter-javascript.so= (or =.dylib= or =.dll=), based on the =:lang=
+field.  The corresponding tree-sitter mode in Emacs is called =js-ts-mode=, and
+all of =js2-mode=, =js-mode=, and =javascript-mode= should attempt switching to the
+=js-ts-mode=, if possible.
+
+Moreover, since =js-2-mode= is first under the =:remap= section, that is the
+"primary fallback."  Meaning that if the tree-sitter grammar is not available,
+it will be the first mode tried.  If that doesn't work, it will try =js-mode=, and
+=javascript-mode=, in that order, until one /does/ work.  If only one fallback needs
+to be specified, a single quoted symbol is also acceptable.  For instance,
+=python-ts-mode= just uses =:remap 'python= in this argument position.
+
+The =:url=, =:revision=, =:source-dir=, =:cc=, and =:c++= arguments are all documented
+under =treesit-language-source-alist=, which is part of base Emacs, not this
+package.
 
 ** Keep track of your hooks
 This package does not modify any of your major mode hooks.  That is, if you have
@@ -156,7 +193,7 @@ loaded.  For major modes in which this is a concern, the current recommendation
 is to address this as part of your configuration.
 
 #+begin_src emacs-lisp
-  (setq rust-ts-mode-hook rust-mode-hook)
+(setq rust-ts-mode-hook rust-mode-hook)
 #+end_src
 
 Some modes have a shared base, such as =python-ts-mode= and =python-mode= both
@@ -167,12 +204,11 @@ deriving from =python-base-mode=.  For these languages, you can opt to hook into
 This is how I configure =treesit-auto= for my own personal use.
 
 #+begin_src emacs-lisp
-    (use-package treesit-auto
-      :demand t
-      :config
-      (add-to-list 'treesit-auto-fallback-alist '(bash-ts-mode . sh-mode))
-      (setq treesit-auto-install 'prompt)
-      (global-treesit-auto-mode))
+(use-package treesit-auto
+  :demand t
+  :config
+  (setq treesit-auto-install 'prompt)
+  (global-treesit-auto-mode))
 #+end_src
 
 * Caveats
@@ -192,3 +228,7 @@ naming, code simplification, and improvements to language in documentation.
 
 Issues are tracked on [[https://github.com/renzmann/treesit-auto/issues][GitHub]], which is also where patches and pull requests
 should be submitted.
+
+If you would like to submit a new language recipe to be distributed as part of
+this package, see [[CONTRIBUTING.md][CONTRIBUTING.md]] for a quick guide on how to write and submit
+the new recipe.

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -284,7 +284,7 @@ Called whenever enabling `global-treesit-auto-mode'."
     (when-let* ((lang (treesit-auto-recipe-lang recipe))
                 (ts-mode (treesit-auto-recipe-ts-mode recipe))
                 (remap (ensure-list (treesit-auto-recipe-remap recipe)))
-                (fallback (car remap)))
+                (fallback (car (seq-filter 'fboundp remap))))
       ;; For lang -> Emacs metadata lookups
       (push `(,lang . ,recipe) treesit-auto--lang-recipe-alist)
       ;; For mode -> lang lookup

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -33,10 +33,13 @@
 (require 'cl-lib)
 
 (defcustom treesit-auto-install nil
-  "If non-nil, auto install the missing grammar for the current `ts-mode'.
+  "If non-nil, auto install the missing tree-sitter grammars.
 
-If set to `prompt' treesit-auto will confirm with the user before
-downloading and installing the grammar."
+This variable takes affect whenever visiting a file that has a
+tree-sitter version available or when using
+`treesit-auto-install-all'.  If set to `prompt' treesit-auto will
+confirm with the user before downloading and installing the
+grammar."
   :type '(choice (const :tag "Yes" t)
                  (const :tag "No" nil)
                  (const :tag "Ask" prompt))

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -1,4 +1,4 @@
-;;; treesit-auto.el --- Automatically use tree-sitter enhanced major modes when available  -*- lexical-binding: t -*-
+;;; treesit-auto.el --- Automatically use tree-sitter enhanced major modes -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2023 Robert Enzmann
 
@@ -32,39 +32,8 @@
 (require 'treesit)
 (require 'cl-lib)
 
-(defcustom treesit-auto-fallback-alist
-  (mapcar
-   (lambda (elt)
-     (cons (purecopy (car elt)) (cdr elt)))
-   `((toml-ts-mode . conf-toml-mode)
-     (html-ts-mode . mhtml-mode)
-     (json-ts-mode . js-json-mode)
-     ;; See deprecation note in their README: https://github.com/emacs-typescript/typescript.el#a-short-note-on-development-halt
-     (typescript-ts-mode . nil)
-     (tsx-ts-mode . nil)))
-  "Alist mapping tree-sitter modes to their respective fallback modes.
-
-If the CDR of the association is nil, then no fallback will be
-attempted when encountering a tree-sitter mode that is missing an
-installation of its respective grammar.  If the CDR is non-nil,
-then a fallback attempt is made to the specified mode.
-
-If a tree-sitter mode is omitted from the keys of this alist
-entirely, then a fallback is attempted by using the same name
-prefix.  For example, `python-ts-mode' will attempt a fallback to
-`python-mode'.
-
-In any case, if the fallback mode does not exist, then no
-fallback is attempted.  One example of this would be for
-`go-mod-mode', which would be the automatic fallback for
-`go-mod-ts-mode'.  If `go-mod-mode' isn't installed, then Emacs
-will still use its default behavior of using `go-mod-ts-mode',
-regardless of whether the grammar is installed or not."
-  :type '(alist (symbol) (function))
-  :group 'treesit)
-
 (defcustom treesit-auto-install nil
-  "If non-nil auto install the missing grammar for the current `ts-mode'.
+  "If non-nil, auto install the missing grammar for the current `ts-mode'.
 
 If set to `prompt' treesit-auto will confirm with the user before
 downloading and installing the grammar."
@@ -73,156 +42,260 @@ downloading and installing the grammar."
                  (const :tag "Ask" prompt))
   :group 'treesit)
 
-(defvar treesit-auto--language-source-alist
-  '((bash "https://github.com/tree-sitter/tree-sitter-bash")
-    (bibtex "https://github.com/latex-lsp/tree-sitter-bibtex")
-    (c "https://github.com/tree-sitter/tree-sitter-c")
-    (c-sharp "https://github.com/tree-sitter/tree-sitter-c-sharp")
-    (clojure "https://github.com/sogaiu/tree-sitter-clojure")
-    (cmake "https://github.com/uyha/tree-sitter-cmake")
-    (commonlisp "https://github.com/theHamsta/tree-sitter-commonlisp")
-    (cpp "https://github.com/tree-sitter/tree-sitter-cpp")
-    (css "https://github.com/tree-sitter/tree-sitter-css")
-    (css-in-js "https://github.com/orzechowskid/tree-sitter-css-in-js")
-    (dockerfile "https://github.com/camdencheek/tree-sitter-dockerfile")
-    (elisp "https://github.com/Wilfred/tree-sitter-elisp")
-    (go "https://github.com/tree-sitter/tree-sitter-go")
-    (gomod "https://github.com/camdencheek/tree-sitter-go-mod")
-    (html "https://github.com/tree-sitter/tree-sitter-html")
-    (java "https://github.com/tree-sitter/tree-sitter-java")
-    (julia "https://github.com/tree-sitter/tree-sitter-julia")
-    (javascript . ("https://github.com/tree-sitter/tree-sitter-javascript" "master" "src"))
-    (json "https://github.com/tree-sitter/tree-sitter-json")
-    (latex "https://github.com/latex-lsp/tree-sitter-latex")
-    (lua "https://github.com/Azganoth/tree-sitter-lua")
-    (make "https://github.com/alemuller/tree-sitter-make")
-    (markdown "https://github.com/ikatyang/tree-sitter-markdown")
-    (python "https://github.com/tree-sitter/tree-sitter-python")
-    (r "https://github.com/r-lib/tree-sitter-r")
-    (ruby "https://github.com/tree-sitter/tree-sitter-ruby")
-    (rust "https://github.com/tree-sitter/tree-sitter-rust")
-    (toml "https://github.com/tree-sitter/tree-sitter-toml")
-    (tsx . ("https://github.com/tree-sitter/tree-sitter-typescript" "master" "tsx/src"))
-    (typescript . ("https://github.com/tree-sitter/tree-sitter-typescript" "master" "typescript/src"))
-    (yaml "https://github.com/ikatyang/tree-sitter-yaml"))
-  "Default repository URLs for `treesit-install-language-grammar'.")
+(defcustom treesit-auto-fallback-alist nil
+  "Ignored.
 
-(defun treesit-auto--available-modes ()
-  "Build a list of all modes ending with `-ts-mode' as strings."
-  (let ((result '()))
-    (mapatoms (lambda (elt)
-                (when-let* ((is-func (functionp elt))
-                            (name (symbol-name elt))
-                            (match (string-match "-ts-mode$" name))
-                            (no-internals (not (string-match "--" name))))
-                  (push (intern name) result))))
-    result))
+Formerly the method of defining fallback & promotion modes
+between tree-sitter and original modes.  This is handled instead
+by manipulating the `treesit-auto-recipe-list' variable."
+  :type '(alist (symbol) (function))
+  :group 'treesit)
 
-(defvar treesit-auto--name-lang-alist
-  '((c++ . cpp)
-    (js . javascript)
-    (common-lisp . commonlisp)
-    (csharp . c-sharp)
-    (go-mod . gomod))
-  "Alist defining the `lang' symbol for a given tree-sitter mode.
+(defcustom treesit-auto-langs nil
+  "Language symbols that should be automatically installed.
 
-This is for the special case of when the `lang' passed
-`treesit-install-language-grammar' is different than the mode
-prefix.  Each entry should have the form (PREFIX . LANG).")
+Setting this to a list of grammar symbols will modify the
+behavior of `treesit-auto-install-all' and the
+automatic/prompting behavior when visiting a buffer that has a
+tree-sitter mode available.  For example, when set to \\='(python
+rust go), then `treesit-auto-install-all' will only check and
+install those three grammars.  Likewise, we will only get
+automatic installation (or prompting, based on the value of
+`treesit-auto-install') when visiting a Python, Go, or Rust file."
+  :type '(list (symbol))
+  :group 'treesit)
 
-(defun treesit-auto--extract-name (name-ts-mode)
-  "Get language from the first component of NAME-TS-MODE as a string."
-  (replace-regexp-in-string "\\(.*\\)-ts-mode$" "\\1" name-ts-mode))
+(cl-defstruct treesit-auto-recipe
+  "Emacs metadata for a tree-sitter language grammar."
+  lang ts-mode remap url revision source-dir cc c++)
 
-(defun treesit-auto--string-convert-ts-name (name-ts-mode)
-  "Convert NAME-TS-MODE, a string, to `name-mode', a symbol."
-  (intern (concat (treesit-auto--extract-name name-ts-mode) "-mode")))
+(defvar treesit-auto-recipe-list
+  `(
+    ,(make-treesit-auto-recipe
+      :lang 'bash
+      :ts-mode 'bash-ts-mode
+      :remap 'sh-mode
+      :url "https://github.com/tree-sitter/tree-sitter-bash")
+    ,(make-treesit-auto-recipe
+      :lang 'bibtex
+      :ts-mode 'bibtex-ts-mode
+      :remap 'bibtex-mode
+      :url "https://github.com/latex-lsp/tree-sitter-bibtex")
+    ,(make-treesit-auto-recipe
+      :lang 'c
+      :ts-mode 'c-ts-mode
+      :remap 'c-mode
+      :url "https://github.com/tree-sitter/tree-sitter-c")
+    ,(make-treesit-auto-recipe
+      :lang 'c-sharp
+      :ts-mode 'csharp-ts-mode
+      :remap 'csharp-mode
+      :url "https://github.com/tree-sitter/tree-sitter-c-sharp")
+    ,(make-treesit-auto-recipe
+      :lang 'clojure
+      :ts-mode 'clojure-ts-mode
+      :remap 'clojure-mode
+      :url "https://github.com/sogaiu/tree-sitter-clojure")
+    ,(make-treesit-auto-recipe
+      :lang 'cmake
+      :ts-mode 'cmake-ts-mode
+      :remap 'cmake-mode
+      :url "https://github.com/uyha/tree-sitter-cmake")
+    ,(make-treesit-auto-recipe
+      :lang 'commonlisp
+      :ts-mode 'commonlisp-ts-mode
+      :remap 'common-lisp-mode
+      :url "https://github.com/theHamsta/tree-sitter-commonlisp")
+    ,(make-treesit-auto-recipe
+      :lang 'cpp
+      :ts-mode 'c++-ts-mode
+      :remap 'c++-mode
+      :url "https://github.com/tree-sitter/tree-sitter-cpp")
+    ,(make-treesit-auto-recipe
+      :lang 'css
+      :ts-mode 'css-ts-mode
+      :remap 'css-mode
+      :url "https://github.com/tree-sitter/tree-sitter-css")
+    ,(make-treesit-auto-recipe
+      :lang 'dockerfile
+      :ts-mode 'dockerfile-ts-mode
+      :remap 'dockerfile-mode
+      :url "https://github.com/camdencheek/tree-sitter-dockerfile")
+    ,(make-treesit-auto-recipe
+      :lang 'go
+      :ts-mode 'go-ts-mode
+      :remap 'go-mode
+      :url "https://github.com/tree-sitter/tree-sitter-go")
+    ,(make-treesit-auto-recipe
+      :lang 'gomod
+      :ts-mode 'go-mod-ts-mode
+      :remap 'go-mod-mode
+      :url "https://github.com/camdencheek/tree-sitter-go-mod")
+    ,(make-treesit-auto-recipe
+      :lang 'html
+      :ts-mode 'html-ts-mode
+      :remap '(mhtml-mode sgml-mode)
+      :url "https://github.com/tree-sitter/tree-sitter-html")
+    ,(make-treesit-auto-recipe
+      :lang 'java
+      :ts-mode 'java-ts-mode
+      :remap 'java-mode
+      :url "https://github.com/tree-sitter/tree-sitter-java")
+    ,(make-treesit-auto-recipe
+      :lang 'julia
+      :ts-mode 'julia-ts-mode
+      :remap 'julia-mode
+      :url "https://github.com/tree-sitter/tree-sitter-julia")
+    ,(make-treesit-auto-recipe
+      :lang 'javascript
+      :ts-mode 'js-ts-mode
+      :remap '(js-mode javascript-mode js2-mode)
+      :url "https://github.com/tree-sitter/tree-sitter-javascript"
+      :revision "master"
+      :source-dir "src")
+    ,(make-treesit-auto-recipe
+      :lang 'json
+      :ts-mode 'json-ts-mode
+      :remap 'js-json-mode
+      :url "https://github.com/tree-sitter/tree-sitter-json")
+    ,(make-treesit-auto-recipe
+      :lang 'latex
+      :ts-mode 'latex-ts-mode
+      :remap 'latex-mode
+      :url "https://github.com/latex-lsp/tree-sitter-latex")
+    ,(make-treesit-auto-recipe
+      :lang 'lua
+      :ts-mode 'lua-ts-mode
+      :remap 'lua-mode
+      :url "https://github.com/Azganoth/tree-sitter-lua")
+    ,(make-treesit-auto-recipe
+      :lang 'make
+      :ts-mode 'makefile-ts-mode
+      :remap 'makefile-mode
+      :url "https://github.com/alemuller/tree-sitter-make")
+    ,(make-treesit-auto-recipe
+      :lang 'markdown
+      :ts-mode 'markdown-ts-mode
+      :remap '(poly-markdown-mode markdown-mode)
+      :url "https://github.com/ikatyang/tree-sitter-markdown")
+    ,(make-treesit-auto-recipe
+      :lang 'python
+      :ts-mode 'python-ts-mode
+      :remap 'python-mode
+      :url "https://github.com/tree-sitter/tree-sitter-python")
+    ,(make-treesit-auto-recipe
+      :lang 'r
+      :ts-mode 'r-ts-mode
+      :remap 'ess-mode
+      :url "https://github.com/r-lib/tree-sitter-r")
+    ,(make-treesit-auto-recipe
+      :lang 'ruby
+      :ts-mode 'ruby-ts-mode
+      :remap 'ruby-mode
+      :url "https://github.com/tree-sitter/tree-sitter-ruby")
+    ,(make-treesit-auto-recipe
+      :lang 'rust
+      :ts-mode 'rust-ts-mode
+      :remap 'rust-mode
+      :url "https://github.com/tree-sitter/tree-sitter-rust")
+    ,(make-treesit-auto-recipe
+      :lang 'toml
+      :ts-mode 'toml-ts-mode
+      :remap '(conf-toml-mode toml-mode)
+      :url "https://github.com/tree-sitter/tree-sitter-toml")
+    ,(make-treesit-auto-recipe
+      :lang 'tsx
+      :ts-mode 'tsx-ts-mode
+      :url "https://github.com/tree-sitter/tree-sitter-typescript"
+      :revision "master"
+      :source-dir "tsx/src")
+    ,(make-treesit-auto-recipe
+      :lang 'typescript
+      :ts-mode 'typescript-ts-mode
+      :url "https://github.com/tree-sitter/tree-sitter-typescript"
+      :revision "master"
+      :source-dir "typescript/src")
+    ,(make-treesit-auto-recipe
+      :lang 'yaml
+      :ts-mode 'yaml-ts-mode
+      :remap 'yaml-mode
+      :url "https://github.com/ikatyang/tree-sitter-yaml")
+    )
+    "Map each tree-sitter lang to Emacs metadata.")
 
-;; FIXME `ts-name' is a confusing variable name.  Change to name-ts-mode
-(defun treesit-auto--get-assoc (ts-name)
-  "Build a cons like (`name-ts-mode' . `name-mode') based on TS-NAME."
-  (or (assq ts-name treesit-auto-fallback-alist)
-      (when-let (fallback-assoc (rassq ts-name treesit-auto-fallback-alist))
-        ;; Reverse order so that ts-mode comes first
-        `(,(cdr fallback-assoc) . ,(car fallback-assoc)))
-      (when-let ((auto-name (treesit-auto--string-convert-ts-name (symbol-name ts-name)))
-                 ((fboundp auto-name)))
-        `(,ts-name .  ,auto-name))
-      `(,ts-name . nil)))
+(defvar treesit-auto--lang-recipe-alist
+  nil
+  "Lookup recipe by lang.")
 
-(defun treesit-auto--available-alist ()
-  "Alist of available tree-sitter modes with their fallback modes."
-  (mapcar 'treesit-auto--get-assoc (treesit-auto--available-modes)))
+(defvar treesit-auto--mode-lang-alist
+  nil
+  "Lookup lang by remap mode.")
 
-(defvar treesit-auto--available-alist
-  (treesit-auto--available-alist)
-  "Alist of available tree-sitter modes with their fallback modes.")
+(defvar treesit-auto--original-language-source-alist
+  (purecopy treesit-language-source-alist)
+  "Keep track of `treesit-language-source-alist'.")
 
-(defun treesit-auto--lang (mode)
-  "Determine the tree-sitter language symbol for MODE."
-  (let* ((ts-mode (car (or (rassq mode treesit-auto--available-alist)
-                           (assq mode treesit-auto--available-alist))))
-         (ts-prefix (intern (treesit-auto--extract-name (symbol-name ts-mode)))))
-    (or (alist-get ts-prefix treesit-auto--name-lang-alist)
-        ts-prefix)))
+(defvar treesit-auto--original-major-mode-remap-alist
+  (purecopy major-mode-remap-alist)
+  "Keep track of `major-mode-remap-alist'.")
+
+(defun treesit-auto--build-alists ()
+  "Rebuild internal alists from language recipes."
+  (setq treesit-auto--lang-recipe-alist ())
+  (setq treesit-auto--mode-lang-alist ())
+  (dolist (recipe treesit-auto-recipe-list)
+    (when-let* ((lang (treesit-auto-recipe-lang recipe))
+                (ts-mode (treesit-auto-recipe-ts-mode recipe))
+                (remap (ensure-list (treesit-auto-recipe-remap recipe)))
+                (fallback (car remap)))
+      ;; For lang -> Emacs metadata lookups
+      (push `(,lang . ,recipe) treesit-auto--lang-recipe-alist)
+      ;; For mode -> lang lookup
+      (dolist (mode remap)
+        (push `(,mode . ,lang) treesit-auto--mode-lang-alist))
+      (push `(,ts-mode . ,lang) treesit-auto--mode-lang-alist)
+      ;; Tree-sitter <--> fallback automation happens here
+      (if (treesit-auto--ready-p ts-mode)
+          (dolist (mode remap)
+            (add-to-list 'major-mode-remap-alist `(,mode . ,ts-mode)))
+        (when (fboundp fallback)
+          (add-to-list 'major-mode-remap-alist `(,ts-mode . ,fallback))))
+      ;; For `treesit-install-langauge-grammar'
+      (add-to-list 'treesit-language-source-alist
+                   `(,(treesit-auto-recipe-lang recipe)
+                     . (,(treesit-auto-recipe-url recipe)
+                        ,(treesit-auto-recipe-revision recipe)
+                        ,(treesit-auto-recipe-source-dir recipe)
+                        ,(treesit-auto-recipe-cc recipe)
+                        ,(treesit-auto-recipe-c++ recipe)))))))
 
 (defun treesit-auto--ready-p (mode)
   "Determine if MODE is tree-sitter ready.
-
-MODE can be of the form `name-ts-mode', its associated
-original mode, such as `name-mode' or a language symbol, like `name'."
-  (let ((lang (if (alist-get mode treesit-auto--language-source-alist)
-                  ;; In case a lang symbol was passed in
-                  mode
-                (treesit-auto--lang mode))))
-    (treesit-ready-p lang t)))
-
-(defun treesit-auto--lang-to-ts-mode (lang)
-  "Convert LANG, a symbol, to its corresponding tree-sitter major mode."
-  (intern
-   (concat (symbol-name (treesit-auto--lang-to-name lang))
-           "-ts-mode")))
-
-(defun treesit-auto--lang-to-name (lang)
-  "Convert LANG symbol to its corresponding name prefix."
-  (or (car (rassq lang treesit-auto--name-lang-alist))
-      lang))
-
-(defun treesit-auto--remap-language-source (language-source)
-  "Maybe add an entry to `major-mode-remap-alist' for LANGUAGE-SOURCE.
-
-If the grammar is installed, remap the base mode to its
-tree-sitter variant in `major-mode-remap-alist'.  Otherwise,
-remap the tree-sitter variant back to the default mode."
-  (when-let* (;; `lang' is the symbol used in the tree-sitter grammar's
-              ;; parser.c, such as `cpp'.  These are exactly the symbols found
-              ;; in the CAR of each element in `treesit-language-source-alist'.
-              (lang (car language-source))
-              ;; `name' is the prefix to major modes in Emacs, like `c++' for
-              ;; `c++-mode'.  Usually this matches `lang', but not always.
-              (name-ts-mode (treesit-auto--lang-to-ts-mode lang))
-              (fallback-mode (alist-get name-ts-mode treesit-auto--available-alist)))
-    (if (treesit-auto--ready-p name-ts-mode)
-        (add-to-list 'major-mode-remap-alist `(,fallback-mode . ,name-ts-mode))
-      (add-to-list 'major-mode-remap-alist `(,name-ts-mode . ,fallback-mode)))))
+MODE can be either the tree-sitter enhanced version or one of the
+fallback modes."
+  (let* ((lang (alist-get mode treesit-auto--mode-lang-alist))
+         (recipe (alist-get lang treesit-auto--lang-recipe-alist))
+         (ts-mode (treesit-auto-recipe-ts-mode recipe)))
+    (and (treesit-ready-p lang t)
+         (fboundp mode)
+         (fboundp ts-mode))))
 
 (defun treesit-auto--prompt-to-install-package (lang)
   "Ask the user if they want to install a tree-sitter grammar for `LANG'.
 
-Returns `non-nil' if install was completed without error."
-  (let ((repo (alist-get lang treesit-language-source-alist)))
-    (when (cond ((eq t treesit-auto-install) t)
-                ((eq 'prompt treesit-auto-install)
-                 (y-or-n-p (format "Tree-sitter grammar for %s is missing.  Would you like to install it from %s? "
-                                   (symbol-name (treesit-auto--lang-to-name lang))
-                                   (car repo)))))
-      (message "Installing the tree-sitter grammar for %s" lang)
-      ;; treesit-install-language-grammar will return nil if the
-      ;; operation succeeded and 't if a warning was sent to the
-      ;; warning buffer. I don't think this is by design but just
-      ;; because of the way `display-warning' works, so this might not
-      ;; work in the future.
-      (not (treesit-install-language-grammar lang)))))
+non-nil only if installation completed without any errors."
+  (when (cond ((eq t treesit-auto-install) t)
+              ((eq 'prompt treesit-auto-install)
+               (y-or-n-p (format "Tree-sitter grammar for %s is missing.  Install it from %s? "
+                                 (symbol-name lang)
+                                 (car (alist-get lang treesit-language-source-alist))))))
+    (message "Installing the tree-sitter grammar for %s" lang)
+    ;; treesit-install-language-grammar will return nil if the
+    ;; operation succeeded and 't if a warning was sent to the
+    ;; warning buffer. I don't think this is by design but just
+    ;; because of the way `display-warning' works, so this might not
+    ;; work in the future.
+    (not (treesit-install-language-grammar lang))))
 
 (defun treesit-auto--maybe-install-grammar ()
   "Try to install the grammar matching the current major-mode.
@@ -233,30 +306,30 @@ currently registered repository.  If the user chooses to install
 the grammar it will then switch to the tree-sitter powered
 version of the current major-mode."
   (when-let* ((not-ready (not (treesit-auto--ready-p major-mode)))
-              (lang (treesit-auto--lang major-mode))
+              (lang (alist-get major-mode treesit-auto--mode-lang-alist))
+              (recipe (alist-get lang treesit-auto--lang-recipe-alist))
+              (ts-mode (treesit-auto-recipe-ts-mode recipe))
+              (ts-mode-exists (fboundp ts-mode))
               (install-success (treesit-auto--prompt-to-install-package lang)))
-    (funcall (treesit-auto--lang-to-ts-mode lang))))
+    (funcall ts-mode)))
 
-(defcustom treesit-auto-opt-out-list nil
-  "Grammars for `treesit-auto-install-all' to avoid.
-
-For example, to prevent installing the `rust-ts-mode' grammar,
-add \\='rust to this list."
-  :type '(list (symbol))
-  :group 'treesit)
+(defvar treesit-auto-opt-out-list
+  nil
+  "Deprecated: language symbols to avoid when using `treesit-auto-install-all'.")
 
 ;;;###autoload
 (defun treesit-auto-install-all ()
-  "Install all available and maintained grammars.
+  "Install every available, maintained grammar.
 
-Individual grammars can be opted out of by adding them to
-`treesit-auto-opt-out-list'."
+See `treesit-auto-langs' and `treesit-auto-install' for
+how to modify the behavior of this function."
   (interactive)
-  (when-let* ((to-install (seq-filter
-                           (lambda (lang) (not (treesit-auto--ready-p lang)))
-                           (cl-set-difference
-                            (mapcar 'car treesit-auto--language-source-alist)
-                            treesit-auto-opt-out-list)))
+  (when-let* ((to-install (or treesit-auto-langs
+                              (seq-filter
+                               (lambda (lang) (not (treesit-ready-p lang t)))
+                               (cl-set-difference
+                                (mapcar 'car treesit-language-source-alist)
+                                treesit-auto-opt-out-list))))
               (prompt (format "The following tree-sitter grammars are missing:\n%s\n"
                               (mapconcat 'symbol-name to-install "\n"))))
     ;; TODO QOL - it would be nice if this messaged what was installed or at
@@ -267,44 +340,40 @@ Individual grammars can be opted out of by adding them to
               (y-or-n-p "Install missing grammars? "))
       (mapcar 'treesit-install-language-grammar to-install))))
 
-;;;###autoload
-(defun treesit-auto-apply-remap ()
-  "Adjust `major-mode-remap-alist' using installed tree-sitter grammars."
-  (dolist (elt treesit-auto--language-source-alist)
-    (add-to-list 'treesit-language-source-alist elt t))
-  ;; This is what actually modifies `major-mode-remap-alist'
-  (mapcar #'treesit-auto--remap-language-source treesit-language-source-alist))
-
 (defun treesit-auto--install-language-grammar-wrapper (&rest _r)
   "Run `treesit-auto-apply-remap' after `treesit-install-language-grammar'."
-  (treesit-auto-apply-remap))
+  (treesit-auto--build-alists))
+
+(defun treesit-auto--setup ()
+  "Set up global minor mode."
+  (setq treesit-auto--original-major-mode-remap-alist (purecopy major-mode-remap-alist))
+  (setq treesit-auto--original-language-source-alist (purecopy treesit-language-source-alist))
+  ;; TODO add maybe-install hook to all remap modes
+  (treesit-auto--build-alists)
+  (dolist (elt (mapcar 'car treesit-auto--mode-lang-alist))
+    (add-hook (intern (concat (symbol-name elt) "-hook"))
+              #'treesit-auto--maybe-install-grammar))
+  (advice-add 'treesit-install-language-grammar
+	      :after #'treesit-auto--install-language-grammar-wrapper))
+
+(defun treesit-auto--teardown ()
+  "Undo any change made by global minor mode."
+  (advice-remove 'treesit-install-language-grammar
+                 #'treesit-auto--install-language-grammar-wrapper)
+  (dolist (elt (mapcar 'car treesit-auto--mode-lang-alist))
+    (remove-hook (intern (concat (symbol-name elt) "-hook"))
+                 #'treesit-auto--maybe-install-grammar))
+  (setq major-mode-remap-alist (purecopy treesit-auto--original-major-mode-remap-alist))
+  (setq treesit-language-source-alist (purecopy treesit-auto--original-language-source-alist)))
 
 ;;;###autoload
 (define-minor-mode global-treesit-auto-mode
   "Toggle `global-treesit-auto-mode'."
   :group 'treesit
   :global 't
-  ;; To speed things up, this caches all of the user options that cause a
-  ;; tree-sitter and regular mode to get paired together, just for this run
-  (setq treesit-auto--available-alist (treesit-auto--available-alist))
   (if global-treesit-auto-mode
-      (progn
-        (dolist (elt (flatten-tree treesit-auto--available-alist))
-          (add-hook (intern (concat (symbol-name elt) "-hook")) #'treesit-auto--maybe-install-grammar))
-        ;; The use of the alias javascript-mode instead of js-mode in the
-        ;; auto-mode-alist prevents automatic switching. See
-        ;; https://github.com/renzmann/treesit-auto/issues/23
-        (add-to-list 'auto-mode-alist '("\\.js[mx]?\\'" . js-mode))
-        (add-to-list 'auto-mode-alist '("\\.har\\'" . js-mode))
-        (advice-add 'treesit-install-language-grammar
-		    :after #'treesit-auto--install-language-grammar-wrapper)
-        (treesit-auto-apply-remap))
-    ;; https://github.com/renzmann/treesit-auto/issues/23
-    (setq auto-mode-alist (delete '("\\.js[mx]?\\'" . js-mode) auto-mode-alist))
-    (setq auto-mode-alist (delete '("\\.har\\'" . js-mode) auto-mode-alist))
-    (dolist (elt (flatten-tree treesit-auto--available-alist))
-      (remove-hook (intern (concat (symbol-name elt) "-hook")) #'treesit-auto--maybe-install-grammar))
-    (advice-remove 'treesit-install-language-grammar #'treesit-auto--install-language-grammar-wrapper)))
+      (treesit-auto--setup)
+    (treesit-auto--teardown)))
 
 (provide 'treesit-auto)
 ;;; treesit-auto.el ends here

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -27,6 +27,16 @@
 ;; If a tree-sitter grammar is available and installed, use it instead of the
 ;; corresponding default mode.  Conversely, when a tree-sitter grammar is not
 ;; available and a fallback major mode is available/specified, use it instead.
+;;
+;; This package also provides a `treesit-auto-install-all' function, which will
+;; scan for tree-sitter grammars listed in `treesit-auto-recipe-list' that are
+;; not installed or otherwise available on `treesit-extra-load-path'.  Automatic
+;; installation of grammars when visiting a file is controlled by the
+;; `treesit-auto-install' variable, which can be t, nil or `prompt'.  When t,
+;; opening a file with a compatible tree-sitter mode will clone and install the
+;; grammar defined by its recipe, if it isn't already installed.  `prompt' will
+;; display a yes/no question in the minibuffer and wait for confirmation before
+;; attempting the installation.
 
 ;;; Code:
 (require 'treesit)

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -255,11 +255,11 @@ automatic installation (or prompting, based on the value of
       :url "https://github.com/ikatyang/tree-sitter-yaml"))
   "Map each tree-sitter lang to Emacs metadata.")
 
-(defvar treesit-auto--lang-recipe-alist
+(defvar treesit-auto-lang-recipe-alist
   nil
   "Lookup a recipe using a tree-sitter lang symbol.")
 
-(defvar treesit-auto--mode-lang-alist
+(defvar treesit-auto-mode-lang-alist
   nil
   "Lookup tree-sitter lang symbol using an Emacs major mode.")
 
@@ -278,19 +278,19 @@ automatic installation (or prompting, based on the value of
 Applies all of the `treesit-auto' settings to adjust
 `treesit-language-source-alist' and `major-mode-remap-alist'.
 Called whenever enabling `global-treesit-auto-mode'."
-  (setq treesit-auto--lang-recipe-alist ())
-  (setq treesit-auto--mode-lang-alist ())
+  (setq treesit-auto-lang-recipe-alist ())
+  (setq treesit-auto-mode-lang-alist ())
   (dolist (recipe treesit-auto-recipe-list)
     (when-let* ((lang (treesit-auto-recipe-lang recipe))
                 (ts-mode (treesit-auto-recipe-ts-mode recipe))
                 (remap (ensure-list (treesit-auto-recipe-remap recipe)))
                 (fallback (car (seq-filter 'fboundp remap))))
       ;; For lang -> Emacs metadata lookups
-      (push `(,lang . ,recipe) treesit-auto--lang-recipe-alist)
+      (push `(,lang . ,recipe) treesit-auto-lang-recipe-alist)
       ;; For mode -> lang lookup
       (dolist (mode remap)
-        (push `(,mode . ,lang) treesit-auto--mode-lang-alist))
-      (push `(,ts-mode . ,lang) treesit-auto--mode-lang-alist)
+        (push `(,mode . ,lang) treesit-auto-mode-lang-alist))
+      (push `(,ts-mode . ,lang) treesit-auto-mode-lang-alist)
       ;; Tree-sitter <--> fallback automation happens here
       (if (treesit-auto--ready-p ts-mode)
           (dolist (mode remap)
@@ -311,8 +311,8 @@ Called whenever enabling `global-treesit-auto-mode'."
 
 MODE can be either the tree-sitter enhanced version or one of the
 fallback modes."
-  (let* ((lang (alist-get mode treesit-auto--mode-lang-alist))
-         (recipe (alist-get lang treesit-auto--lang-recipe-alist))
+  (let* ((lang (alist-get mode treesit-auto-mode-lang-alist))
+         (recipe (alist-get lang treesit-auto-lang-recipe-alist))
          (ts-mode (treesit-auto-recipe-ts-mode recipe)))
     (and (treesit-ready-p lang t)
          (fboundp mode)
@@ -344,8 +344,8 @@ prompt the user about automatic installation, depending on the
 value of `treesit-auto-install'.  If installation of the grammar
 is successful, activate the tree-sitter major mode."
   (when-let* ((not-ready (not (treesit-auto--ready-p major-mode)))
-              (lang (alist-get major-mode treesit-auto--mode-lang-alist))
-              (recipe (alist-get lang treesit-auto--lang-recipe-alist))
+              (lang (alist-get major-mode treesit-auto-mode-lang-alist))
+              (recipe (alist-get lang treesit-auto-lang-recipe-alist))
               (ts-mode (treesit-auto-recipe-ts-mode recipe))
               (ts-mode-exists (fboundp ts-mode))
               (install-success (treesit-auto--prompt-to-install-package lang)))
@@ -390,7 +390,7 @@ how to modify the behavior of this function."
   (setq treesit-auto--original-language-source-alist (purecopy treesit-language-source-alist))
   ;; TODO add maybe-install hook to all remap modes
   (treesit-auto--build-alists)
-  (dolist (elt (mapcar 'car treesit-auto--mode-lang-alist))
+  (dolist (elt (mapcar 'car treesit-auto-mode-lang-alist))
     (add-hook (intern (concat (symbol-name elt) "-hook"))
               #'treesit-auto--maybe-install-grammar))
   (advice-add 'treesit-install-language-grammar
@@ -400,7 +400,7 @@ how to modify the behavior of this function."
   "Undo any change made by `global-treesit-auto-mode'."
   (advice-remove 'treesit-install-language-grammar
                  #'treesit-auto--install-language-grammar-wrapper)
-  (dolist (elt (mapcar 'car treesit-auto--mode-lang-alist))
+  (dolist (elt (mapcar 'car treesit-auto-mode-lang-alist))
     (remove-hook (intern (concat (symbol-name elt) "-hook"))
                  #'treesit-auto--maybe-install-grammar))
   (setq major-mode-remap-alist (purecopy treesit-auto--original-major-mode-remap-alist))

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -370,7 +370,7 @@ how to modify the behavior of this function."
                                (cl-set-difference
                                 (mapcar 'car treesit-language-source-alist)
                                 treesit-auto-opt-out-list))))
-              (prompt (format "The following tree-sitter grammars are missing:\n%s\n"
+              (prompt (format "The following tree-sitter grammars are/were missing:\n%s\n"
                               (mapconcat 'symbol-name to-install "\n"))))
     ;; TODO QOL - it would be nice if this messaged what was installed or at
     ;; least mentioned that nothing was installed if skipped.

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -73,8 +73,7 @@ automatic installation (or prompting, based on the value of
   lang ts-mode remap url revision source-dir cc c++)
 
 (defvar treesit-auto-recipe-list
-  `(
-    ,(make-treesit-auto-recipe
+  `(,(make-treesit-auto-recipe
       :lang 'bash
       :ts-mode 'bash-ts-mode
       :remap 'sh-mode
@@ -222,8 +221,7 @@ automatic installation (or prompting, based on the value of
       :lang 'yaml
       :ts-mode 'yaml-ts-mode
       :remap 'yaml-mode
-      :url "https://github.com/ikatyang/tree-sitter-yaml")
-    )
+      :url "https://github.com/ikatyang/tree-sitter-yaml"))
     "Map each tree-sitter lang to Emacs metadata.")
 
 (defvar treesit-auto--lang-recipe-alist


### PR DESCRIPTION
1. Information about grammars are now structured into recipes, a common lisp struct.
2. All alist modifications and caching is now done by `treesit-auto--build-alists`
3. The global mode now undoes all modifications when toggled off
4. Deprecation of `treesit-auto-fallback-alist`
5. Deprecation of `treesit-auto-opt-out-list`