### PR TITLE
Handle nil recipe for treesit-auto--ready-p check

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -313,7 +313,7 @@ MODE can be either the tree-sitter enhanced version or one of the
 fallback modes."
   (let* ((lang (alist-get mode treesit-auto-mode-lang-alist))
          (recipe (alist-get lang treesit-auto-lang-recipe-alist))
-         (ts-mode (treesit-auto-recipe-ts-mode recipe)))
+         (ts-mode (when recipe (treesit-auto-recipe-ts-mode recipe))))
     (and (treesit-ready-p lang t)
          (fboundp mode)
          (fboundp ts-mode))))


### PR DESCRIPTION
This is an issue when using `markdown-preview` with `markdown-mode` as there is no html-mode recipe when opening up the html buffer.  There is probably a better solution, but this stops the short term crash.