### PR TITLE
Enable installation of grammars for interdependant languages

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -138,6 +138,7 @@ automatic installation (or prompting, based on the value of
       :lang 'elixir
       :ts-mode 'elixir-ts-mode
       :remap 'elixir-mode
+      :requires 'heex
       :url "https://github.com/elixir-lang/tree-sitter-elixir")
     ,(make-treesit-auto-recipe
       :lang 'go


### PR DESCRIPTION
This has come up for both typescript/tsx in #30 and elixir/heex in #31.  For these languages that embed more than one grammar, the `:requires` keyword is one way to ensure all grammars are installed when visiting an appropriate file.

@wkirschbaum I'm going to include your `:requires` examples from #31 in the case of elixir/heex, and let's keep the discussion open for the other refactor work on either that PR or a new one