### PR TITLE
Fix defcustom `:type`s of `treesit-auto-langs` and (probably obsolete) `treesit-auto-fallback-alist`

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -62,7 +62,7 @@ yes/no prompt when this variable is t."
 Formerly the method of defining fallback & promotion modes
 between tree-sitter and original modes.  This is handled instead
 by manipulating the `treesit-auto-recipe-list' variable."
-  :type '(alist (symbol) (function))
+  :type '(alist :key-type symbol :value-type function)
   :group 'treesit)
 
 (defcustom treesit-auto-langs nil

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -76,7 +76,7 @@ rust go), then `treesit-auto-install-all' will only check and
 install those three grammars.  Likewise, we will only get
 automatic installation (or prompting, based on the value of
 `treesit-auto-install') when visiting a Python, Go, or Rust file."
-  :type '(list (symbol))
+  :type '(repeat symbol)
   :group 'treesit)
 
 (cl-defstruct treesit-auto-recipe


### PR DESCRIPTION
The title already says it: fix `:type` of the defcustom variables `treesit-auto-langs` and `treesit-auto-fallback-alist`.