### PR TITLE
Make sure all components of the recipe are present

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -360,10 +360,15 @@ This variable is ignored if `treesit-auto-langs' is non-nil.")
                      finally return remap-alist))))
 
 (defun treesit-auto--build-treesit-source-alist ()
+  "Construct the `treesit-language-source-alist' using all known recipes."
   (append treesit-language-source-alist
           (cl-loop for recipe in treesit-auto-recipe-list
                    collect (cons (treesit-auto-recipe-lang recipe)
-                                 `(,(treesit-auto-recipe-url recipe))))))
+                                 `(,(treesit-auto-recipe-url recipe)
+                                   ,(treesit-auto-recipe-revision recipe)
+                                   ,(treesit-auto-recipe-source-dir recipe)
+                                   ,(treesit-auto-recipe-cc recipe)
+                                   ,(treesit-auto-recipe-c++ recipe))))))
 
 ;;;###autoload
 (defun treesit-auto-install-all ()


### PR DESCRIPTION
Fixes a lingering bug where not all recipe components are added to `treesit-langauge-source-alist`