### PR TITLE
Enable installation of well-known grammars based on matching file extensions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 0.6.9
+current_version = 1.0.0
 
 [bumpversion:file:treesit-auto.el]

--- a/README.org
+++ b/README.org
@@ -291,6 +291,65 @@ This is how I configure =treesit-auto= for my own personal use.
     (global-treesit-auto-mode))
 #+end_src
 
+* A rough vanilla equivalent
+I find it a good practice to be skeptical of adding any new dependency to my
+Emacs configuration.  So, what would you have to do to get similar behavior in
+your Emacs configuration without the =treesit-auto= package?
+
+We'll take two examples: TypeScript and Python.
+
+Emacs 29 ships with =typescript-ts-mode= and =tsx-ts-mode=, but no equivalent
+=typescript-mode= or =tsx-mode=.  =python-ts-mode= and =python-mode=, on the
+other hand, are both available out of the box.  If you wanted these grammars to
+automatically install on launch, and then use the tree-sitter modes instead of
+the base modes for every file, you'd need the following code in your init file:
+
+#+begin_src emacs-lisp
+  (setq treesit-language-source-alist
+        '((typescript . ("https://github.com/tree-sitter/tree-sitter-typescript" "master" "typescript/src"))
+          (tsx . ("https://github.com/tree-sitter/tree-sitter-typescript" "master" "tsx/src"))
+          (python . ("https://github.com/tree-sitter/tree-sitter-python"))))
+
+  (dolist (source treesit-language-source-alist)
+    (unless (treesit-ready-p (car source))
+      (treesit-install-language-grammar (car source))))
+
+  (add-to-list 'auto-mode-alist '("\\.ts\\'" . typescript-ts-mode))
+  (add-to-list 'auto-mode-alist '("\\.tsx\\'" . tsx-ts-mode))
+  (add-to-list 'major-mode-remap-alist '(python-mode . python-ts-mode))
+
+#+end_src
+
+There are plenty of reasons why some users would prefer to take this type of
+hand-tuned approach to their tree-sitter modes.  For most Emacs people, though,
+you can see the natural progression of where a config like the above would go:
+
++ You need to maintain a library of language symbols (which /must/ match the
+  language's =grammar.js=), URLs, revisions, and sub-directories for
+  =treesit-language-source-alist=.  Additionally, you'd need to know that
+  =typescript-ts-mode= relies on the tree-sitter grammar for =tsx=, which must
+  be installed alongside the grammar for TypeScript.  This is probably the main
+  value proposition of this package, since all of this information is stored
+  under the community-contributed =treesit-auto-recipe-list=
++ You need to be aware of when to use =auto-mode-alist= and
+  =major-mode-remap-alist=, depending on what modes are installed into Emacs
++ If you want lazy installation of grammars, rather than installing them all
+  up-front in your =init.el=, you'd need to write some hooks or derived modes to
+  check =treesit-ready-p= for the current buffer, and install the language
+  before loading the main tree-sitter mode
++ After a certain number of langauges, it becomes unweildy to do these
+  =add-to-list= calls for every single one, and it's better to programmatically
+  operate on a list of selected languages
+
+If you were to follow this chain yourself, you'd probably wind up with something
+in your =init.el= that looks very similar to the code in this package.
+
+All in all, this is a small package.  Roughly half of it is just maintaining a
+library of information for =treesit-language-source-alist=, and the other half
+works through the logic of handling edge cases related to the remaining bullets
+above.
+
+
 * Caveats
 This package is, admittedly, a hack.  =treesit.el= provides an excellent
 foundation to incremental source code parsing for Emacs 29, and over time that

--- a/README.org
+++ b/README.org
@@ -48,6 +48,18 @@ Then, in your Emacs configuration file (=~/.emacs.d/init.el=),
 For most users, this will be enough.  There are some nifty things you might want
 to enable, though, which are covered in the "Configuration" section below.
 
+* Configuration example
+This is how I configure =treesit-auto= for my own personal use.
+
+#+begin_src emacs-lisp
+  (use-package treesit-auto
+    :custom
+    (treesit-auto-install 'prompt)
+    :config
+    (treesit-auto-add-to-auto-mode-alist 'all)
+    (global-treesit-auto-mode))
+#+end_src
+
 * What this package does
 Emacs 29, while featuring =treesit.el= and a convenient
 =treesit-install-language-grammar=, [[https://archive.casouri.cc/note/2023/tree-sitter-in-emacs-29/index.html][will not feature an intelligent way to choose]]
@@ -258,15 +270,15 @@ You can register tree-sitter modes to =auto-mode-alist= by calling
 =treesit-auto-add-to-auto-mode-alist=.  Depending on the optional argument
 =langs=, this function can behave in three different ways:
 
-1. **nil**, the default - Only add tree-sitter modes to =auto-mode-alist= if the
+1. =nil=, the default - Only add tree-sitter modes to =auto-mode-alist= if the
    tree-sitter mode is available to Emacs /and/ the grammar is installed.
-2. **'all** - For every tree-sitter mode available to Emacs and in
+2. ='all= - For every tree-sitter mode available to Emacs and in
    =treesit-auto-langs=, add it to =auto-mode-alist= regardless of whether the
    grammar is installed.  This has the beneficial side effect of installing
    grammars for you when opening files that have a tree-sitter mode that comes
    with Emacs, but have no fallback mode.  Examples of this are =rust-ts-mode=,
    =go-ts-mode=, and a few others in Emacs 29+.
-3. **A list of language symbols** - behaves like ='all=, but only for the listed
+3. *A list of language symbols* - behaves like ='all=, but only for the listed
    languages
 
 For instance, you might run this function as:
@@ -279,18 +291,6 @@ This registers your tree-sitter modes according to the common file extension for
 Rust, Go, and TOML, but no other modes.  Most users will probably want to use
 =(treesit-auto-add-to-auto-mode-alist 'all)= for the easiest general behavior;
 always prompting/installing grammars when we can.
-
-** Full example
-This is how I configure =treesit-auto= for my own personal use.
-
-#+begin_src emacs-lisp
-  (use-package treesit-auto
-    :custom
-    (treesit-auto-install 'prompt)
-    :config
-    (treesit-auto-add-to-auto-mode-alist 'all)
-    (global-treesit-auto-mode))
-#+end_src
 
 * A rough vanilla equivalent
 I find it a good practice to be skeptical of adding any new dependency to my

--- a/README.org
+++ b/README.org
@@ -203,13 +203,14 @@ To create a recipe, use =make-treesit-auto-recipe=:
 
 #+begin_src elisp
   (setq my-js-tsauto-config
-	(make-treesit-auto-recipe
-	 :lang 'javascript
-	 :ts-mode 'js-ts-mode
-	 :remap '(js2-mode js-mode javascript-mode)
-	 :url "https://github.com/tree-sitter/tree-sitter-javascript"
-	 :revision "master"
-	 :source-dir "src"))
+        (make-treesit-auto-recipe
+         :lang 'javascript
+         :ts-mode 'js-ts-mode
+         :remap '(js2-mode js-mode javascript-mode)
+         :url "https://github.com/tree-sitter/tree-sitter-javascript"
+         :revision "master"
+         :source-dir "src"
+         :ext "\\.js\\'"))
 
   (add-to-list 'treesit-auto-recipe-list my-js-tsauto-config)
 #+end_src

--- a/README.org
+++ b/README.org
@@ -363,7 +363,7 @@ to have this plugin available in the meantime.
 * Known bugs
 =treesit-auto= doesn't play super well with Org-babel, since Org has its own
 methods of hooking into and using languages.  In particular, you may need to set
-='org-src-lang-modes= yourself to get tree-sitter modes working correctly.
+=org-src-lang-modes= yourself to get tree-sitter modes working correctly.
 
 Another side behavior you may encounter is when opening an Org document with
 shell scripts inside and =treesit-auto-install= is non-nil, then =treesit-auto=

--- a/README.org
+++ b/README.org
@@ -253,30 +253,42 @@ deriving from =python-base-mode=.  For these languages, you can opt to hook into
 =python-base-mode-hook= instead of explicitly setting the tree-sitter mode's hook.
 
 ** Automatically register extensions for =auto-mode-alist=
-This is an optional feature so that this package avoids mutating your
-=auto-mode-alist= without your permission.
+You can register tree-sitter modes to =auto-mode-alist= by calling
+=treesit-auto-add-to-auto-mode-alist=.  Depending on the optional argument
+=langs=, this function can behave in three different ways:
 
-After your desired grammars are installed, you can register them to
-=auto-mode-alist= by calling =treesit-auto-add-to-auto-mode-alist=. This function
-will only add grammars that are considered ready (i.e. detected as installed).
+1. **nil**, the default - Only add tree-sitter modes to =auto-mode-alist= if the
+   tree-sitter mode is available to Emacs /and/ the grammar is installed.
+2. **'all** - For every tree-sitter mode available to Emacs and in
+   =treesit-auto-langs=, add it to =auto-mode-alist= regardless of whether the
+   grammar is installed.  This has the beneficial side effect of installing
+   grammars for you when opening files that have a tree-sitter mode that comes
+   with Emacs, but have no fallback mode.  Examples of this are =rust-ts-mode=,
+   =go-ts-mode=, and a few others in Emacs 29+.
+3. **A list of language symbols** - behaves like ='all=, but only for the listed
+   languages
+
+For instance, you might run this function as:
 
 #+begin_src emacs-lisp
-(treesit-auto-add-to-auto-mode-alist)
+(treesit-auto-add-to-auto-mode-alist '(rust go toml))
 #+end_src
 
-This registers your tree-sitter modes according to the common file
-extension for that language. For example, the =auto-mode-alist= entry
-for TypeScript looks like ='("\\*.ts\\'" . typescript-ts-mode)=.
+This registers your tree-sitter modes according to the common file extension for
+Rust, Go, and TOML, but no other modes.  Most users will probably want to use
+=(treesit-auto-add-to-auto-mode-alist 'all)= for the easiest general behavior;
+always prompting/installing grammars when we can.
 
 ** Full example
 This is how I configure =treesit-auto= for my own personal use.
 
 #+begin_src emacs-lisp
-(use-package treesit-auto
-  :demand t
-  :config
-  (setq treesit-auto-install 'prompt)
-  (global-treesit-auto-mode))
+  (use-package treesit-auto
+    :custom
+    (treesit-auto-install 'prompt)
+    :config
+    (treesit-auto-add-to-auto-mode-alist 'all)
+    (global-treesit-auto-mode))
 #+end_src
 
 * Caveats
@@ -287,6 +299,17 @@ mind, I fully expect this package to eventually be obsolesced by the default
 options in Emacs 30 and beyond.  That does not preclude us from adding a few
 quality of life improvements to Emacs 29, though, and so it still seems prudent
 to have this plugin available in the meantime.
+
+* Known bugs
+=treesit-auto= doesn't play super well with Org-babel, since Org has its own
+methods of hooking into and using languages.  In particular, you may need to set
+='org-src-lang-modes= yourself to get tree-sitter modes working correctly.
+
+Another side behavior you may encounter is when opening an Org document with
+shell scripts inside and =treesit-auto-install= is non-nil, then =treesit-auto=
+will prompt to install the Bash grammar, but won't display the prompt until you
+interact with Emacs in some way, such as using =next-line= (=C-n= by default) or
+hovering over Emacs with your mouse.
 
 * Contributing
 Bug reports, feature requests, and contributions are most welcome.  Even though

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -5,7 +5,7 @@
 ;; Author: Robb Enzmann <robbenzmann@gmail.com>
 ;; Keywords: treesitter auto automatic major mode fallback convenience
 ;; URL: https://github.com/renzmann/treesit-auto.git
-;; Version: 0.6.9
+;; Version: 1.0.0
 ;; Package-Requires: ((emacs "29.0"))
 
 ;; This file is not part of GNU Emacs.

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -227,7 +227,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'makefile-ts-mode
       :remap 'makefile-mode
       :url "https://github.com/alemuller/tree-sitter-make"
-      :ext "\\Makefile\\'")
+      :ext "\\([Mm]akefile\\|.*\\.\\(mk\\|make\\)\\)\\'")
     ,(make-treesit-auto-recipe
       :lang 'markdown
       :ts-mode 'markdown-ts-mode
@@ -251,13 +251,13 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'r-ts-mode
       :remap 'ess-mode
       :url "https://github.com/r-lib/tree-sitter-r"
-      :ext "\\(?:\\.\\(?:rbw?\\|ru\\|rake\\|thor\\|jbuilder\\|rabl\\|gemspec\\|podspec\\)\\|/\\(?:Gem\\|Rake\\|Cap\\|Thor\\|Puppet\\|Berks\\|Brew\\|Vagrant\\|Guard\\|Pod\\)file\\)\\'")
+      :ext "\\.r\\'")
     ,(make-treesit-auto-recipe
       :lang 'ruby
       :ts-mode 'ruby-ts-mode
       :remap 'ruby-mode
       :url "https://github.com/tree-sitter/tree-sitter-ruby"
-      :ext "\\.rb\\'")
+      :ext "\\(?:\\.\\(?:rbw?\\|ru\\|rake\\|thor\\|jbuilder\\|rabl\\|gemspec\\|podspec\\)\\|/\\(?:Gem\\|Rake\\|Cap\\|Thor\\|Puppet\\|Berks\\|Brew\\|Vagrant\\|Guard\\|Pod\\)file\\)\\'")
     ,(make-treesit-auto-recipe
       :lang 'rust
       :ts-mode 'rust-ts-mode
@@ -390,10 +390,6 @@ Non-nil only if installation completed without any errors."
 
 (defun treesit-auto--get-buffer-recipe ()
   "Look up the recipe for the current buffer using its extension."
-  ;; Only do this if we aren't about to load a mode for real.  Otherwise, the
-  ;; installation function would be called twice; once when the buffer loads in
-  ;; fundamental mode, and again when the main mode loads.
-  ;; https://debbugs.gnu.org/db/11/11929.html
   (seq-find (lambda (r) (string-match (treesit-auto-recipe-ext r) (buffer-name)))
             (treesit-auto--selected-recipes)))
 
@@ -487,8 +483,6 @@ how to modify the behavior of this function."
   ;; replacement and ignores all changes while this mode is active, so
   ;; don't think it is a valid option.
   (setq-local major-mode-remap-alist (treesit-auto--build-major-mode-remap-alist)))
-
-(defvar treesit-auto--called nil)
 
 (defun treesit-auto--on ()
   "Turn `treesit-auto-mode' on."


### PR DESCRIPTION
Without this patch, opening up a `hello.rs` without `rust-mode` installed just leaves us in `fundamental-mode` without any of the expected benefits of `treesit-auto`.

This patch enables `treesit-auto` to install the grammar for a mode if the corresponding `ts-mode` is already installed, even if no fallback mode is installed.  Some examples of ts-modes that come with Emacs 29 that don't have a fallback mode are:

1. `rust-ts-mode`
2. `yaml-ts-mode`
3. `toml-ts-mode`
4. `go-ts-mode`