### PR TITLE
Fix treesit-auto-add-to-auto-mode-alist when langs is nil

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -520,7 +520,7 @@ missing from `treesit-auto-langs', then it will not be added to
 `auto-mode-alist', even if it is listed in LANGS."
   (let* ((selected-recipes (treesit-auto--selected-recipes))
          (recipes (cond ((eq langs 'all) selected-recipes)
-                        ((listp langs) (treesit-auto--filter-recipes-with-langs langs selected-recipes))
+                        ((and langs (listp langs)) (treesit-auto--filter-recipes-with-langs langs selected-recipes))
                         (t (seq-filter #'treesit-auto--recipe-ready-p selected-recipes)))))
     (dolist (r recipes)
       (add-to-list 'auto-mode-alist


### PR DESCRIPTION
`(listp langs)` return `t` when `langs` is nil. It results in empty recipes so nothing's really added.

> listp is a built-in function in ‘C source code’.
> 
> (listp OBJECT)
> 
> Return t if OBJECT is a list, that is, a cons cell or nil.
Otherwise, return nil.

I believe this should also fix https://github.com/renzmann/treesit-auto/issues/66.

BTW, thanks for such a great package xD