### PR TITLE
Use the Lua treesit grammar referenced by `lua-ts-mode`

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -220,7 +220,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :lang 'lua
       :ts-mode 'lua-ts-mode
       :remap 'lua-mode
-      :url "https://github.com/Azganoth/tree-sitter-lua"
+      :url "https://github.com/MunifTanjim/tree-sitter-lua"
       :ext "\\.lua\\'")
     ,(make-treesit-auto-recipe
       :lang 'make


### PR DESCRIPTION
See https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=b6659e98a4fcaa44477b64d7782243feca020418 and https://git.sr.ht/~johnmuhl/lua-ts-mode

If there's another `lua-ts-mode`, I'm unaware of it.