### PR TITLE
Remove recipe: magik

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -223,12 +223,6 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :url "https://github.com/MunifTanjim/tree-sitter-lua"
       :ext "\\.lua\\'")
     ,(make-treesit-auto-recipe
-      :lang 'magik
-      :ts-mode 'magik-ts-mode
-      :remap 'magik-mode
-      :url "https://github.com/krn-robin/tree-sitter-magik"
-      :ext "\\.magik\\'")
-    ,(make-treesit-auto-recipe
       :lang 'make
       :ts-mode 'makefile-ts-mode
       :remap 'makefile-mode


### PR DESCRIPTION
The package `magik-mode` will determine itself if we want to use `magik-mode` or `magik-ts-mode`. Since we have this implemented, this recipe is not needed anymore here. Right now, this change caused a nesting loop when opening a Magik-file and not having the dll for `tree-sitter-magik` installed. It would try (and fail) to open it in `magik-ts-mode` and kept on trying until `Debugger entered--Lisp error: (error "Lisp nesting exceeds ‘max-lisp-eval-depth’")`