### PR TITLE
Improve dockerfile-ts-mode regex to take into account Containerfile

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -144,7 +144,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'dockerfile-ts-mode
       :remap 'dockerfile-mode
       :url "https://github.com/camdencheek/tree-sitter-dockerfile"
-      :ext "\\Dockerfile\\'")
+      :ext "/\\(?:Containerfile\\|Dockerfile\\)\\'")
     ,(make-treesit-auto-recipe
       :lang 'elixir
       :ts-mode 'elixir-ts-mode

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -144,7 +144,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'dockerfile-ts-mode
       :remap 'dockerfile-mode
       :url "https://github.com/camdencheek/tree-sitter-dockerfile"
-      :ext "/\\(?:Containerfile\\|Dockerfile\\)\\'")
+      :ext "[/\\]\\(?:Containerfile\\|Dockerfile\\)\\(?:\\.[^/\\]*\\)?\\'")
     ,(make-treesit-auto-recipe
       :lang 'elixir
       :ts-mode 'elixir-ts-mode


### PR DESCRIPTION
Hello!

Current regex doesn't seem to take into account Containerfile. This would fix that.