### PR TITLE
Make compatible with existing `markdown-ts-mode`

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -256,6 +256,8 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'markdown-ts-mode
       :remap '(poly-markdown-mode markdown-mode)
       :url "https://github.com/tree-sitter-grammars/tree-sitter-markdown"
+      :revision "split_parser"
+      :source-dir "tree-sitter-markdown/src"
       :ext "\\.md\\'")
     ,(make-treesit-auto-recipe
       :lang 'nu


### PR DESCRIPTION
A [`markdown-ts-mode`](https://github.com/LionyxML/markdown-ts-mode) was recently published to [Melpa](https://melpa.org/#/markdown-ts-mode). I've updated the config to reflect the correct config.

Trying to figure out how to use multiple grammars.