### PR TITLE
Add support for nix-ts-mode

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -258,6 +258,12 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :url "https://github.com/tree-sitter-grammars/tree-sitter-markdown"
       :ext "\\.md\\'")
     ,(make-treesit-auto-recipe
+      :lang 'nix
+      :ts-mode 'nix-ts-mode
+      :remap 'nix-mode
+      :url "https://github.com/nix-community/tree-sitter-nix"
+      :ext "\\.nix\\'")
+    ,(make-treesit-auto-recipe
       :lang 'nu
       :ts-mode 'nushell-ts-mode
       :remap 'nushell-mode


### PR DESCRIPTION
Hello, thanks for the great repo that elegantly handles this weird normal/ts mode topic :)

I've simply added an `treesit-auto-recipe` to map [`nix-mode`](https://github.com/NixOS/nix-mode) to [`nix-ts-mode`](https://github.com/nix-community/nix-ts-mode).