### PR TITLE
Fix grammar of C++

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -132,6 +132,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'c++-ts-mode
       :remap 'c++-mode
       :url "https://github.com/tree-sitter/tree-sitter-cpp"
+      :revision "v0.22.0" ;; BUG: newer grammar breaks syntax highlighting in `c++-ts-mode'
       :ext "\\.cpp\\'")
     ,(make-treesit-auto-recipe
       :lang 'css


### PR DESCRIPTION
It seems like the new `treesitter-cpp` grammar breaks syntax highlighting for
C++.

I've done a bisecting of the revisions of the grammar and found that the last
working version is v0.22.0. More info is available on this [discussion](https://github.com/abougouffa/minemacs/discussions/135).

You can check the issue on a vanilla Emacs using:

## Buggy version (latest commit)

`emacs -Q -l treesit-cpp-buggy.el`

```elisp
;; treesit-cpp-buggy.el
(setq treesit-language-source-alist
      '((cpp "https://github.com/tree-sitter/tree-sitter-cpp" nil nil nil nil)))
(treesit-install-language-grammar 'cpp)
```

## Working version (v0.22.0)

`emacs -Q -l treesit-cpp-fixed.el`

```elisp
;; treesit-cpp-fixed.el
(setq treesit-language-source-alist
      '((cpp "https://github.com/tree-sitter/tree-sitter-cpp" "v0.22.1" nil nil nil)))
(treesit-install-language-grammar 'cpp)
```