### PR TITLE
New Recipe: php-ts-mode

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -210,6 +210,11 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :source-dir "src"
       :ext "\\.js\\'")
     ,(make-treesit-auto-recipe
+      :lang 'jsdoc
+      :ts-mode 'php-ts-mode
+      :url "https://github.com/tree-sitter/tree-sitter-jsdoc"
+      :ext "\\.php\\'")
+    ,(make-treesit-auto-recipe
       :lang 'json
       :ts-mode 'json-ts-mode
       :remap 'js-json-mode
@@ -281,6 +286,17 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :remap 'perl-mode
       :url "https://github.com/ganezdragon/tree-sitter-perl"
       :ext "\\.pl\\'")
+    ,(make-treesit-auto-recipe
+      :lang 'php
+      :ts-mode 'php-ts-mode
+      :url "https://github.com/tree-sitter/tree-sitter-php"
+      :source-dir "php/src"
+      :ext "\\.php\\'")
+    ,(make-treesit-auto-recipe
+      :lang 'phpdoc
+      :ts-mode 'php-ts-mode
+      :url "https://github.com/claytonrcarter/tree-sitter-phpdoc"
+      :ext "\\.php\\'")
     ,(make-treesit-auto-recipe
       :lang 'proto
       :ts-mode 'protobuf-ts-mode


### PR DESCRIPTION
Emacs 30+ [introduces a native `php-ts-mode`](https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/progmodes/php-ts-mode.el?h=emacs-30); I've been using it for a few weeks and it seems to work fine. The new mode depends on all three of these recipes; I'm opening this as a single PR but if you prefer I can close this one and resubmit it as three different ones as described in the contributing guidelines. 

Thanks for this package!