### PR TITLE
Fix incorrect Janet recipe lang

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -190,7 +190,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :url "https://github.com/tree-sitter/tree-sitter-html"
       :ext "\\.html\\'")
     ,(make-treesit-auto-recipe
-      :lang 'janet
+      :lang 'janet-simple
       :ts-mode 'janet-ts-mode
       :remap 'janet-mode
       :url "https://github.com/sogaiu/tree-sitter-janet-simple"


### PR DESCRIPTION
Hello!

It seems that Janet recipe uses wrong `:lang` and because of that grammar is recompiled with a wrong name every time `*.janet` file is entered. As can be seen in [tree-sitter-janet-simple grammar.js](https://github.com/sogaiu/tree-sitter-janet-simple/blob/master/grammar.js#L52) or in [janet-ts-mode setup instructions](https://github.com/sogaiu/janet-ts-mode?tab=readme-ov-file#setup) the correct grammar name is `janet-simple`. 