### PR TITLE
make c and cpp recipes depend on each other

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -102,6 +102,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'c-ts-mode
       :remap 'c-mode
       :url "https://github.com/tree-sitter/tree-sitter-c"
+      :requires 'cpp
       :ext "\\.c\\'")
     ,(make-treesit-auto-recipe
       :lang 'c-sharp
@@ -131,6 +132,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :lang 'cpp
       :ts-mode 'c++-ts-mode
       :remap 'c++-mode
+      :requires 'c
       :url "https://github.com/tree-sitter/tree-sitter-cpp"
       :ext "\\.cpp\\'")
     ,(make-treesit-auto-recipe


### PR DESCRIPTION
When `c-ts-mode.el` loaded, it evaluates

```lisp
(and (treesit-ready-p 'cpp)
     (treesit-ready-p 'c))
```

which pops up a warning every time even though treesit-auto install
mode specific tree-sitter. This was unexpected as we asked
treesit-auto to install libraries and it is okay with it. Users may
still get the warning but before libraries are installed and only once
across Emacs sessions.

This should fix #92 #104 #124 .