### PR TITLE
feat: add TypeSpec

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -354,6 +354,13 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :source-dir "typescript/src"
       :ext "\\.ts\\'")
     ,(make-treesit-auto-recipe
+      :lang 'typespec
+      :ts-mode 'typespec-ts-mode
+      :url "https://github.com/happenslol/tree-sitter-typespec/"
+      :revision "main"
+      :source-dir "src"
+      :ext "\\.tsp\\'")
+    ,(make-treesit-auto-recipe
       :lang 'typst
       :ts-mode 'typst-ts-mode
       :remap 'typst-mode


### PR DESCRIPTION
Note that as of 2025-03-10,
the rule's compatible ABI is v15 and Emacs' tree-sitter compatible ABI must be v15 or higher.
