### PR TITLE
Update verilog recipe

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -365,7 +365,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :lang 'verilog
       :ts-mode 'verilog-ts-mode
       :remap 'verilog-mode
-      :url "https://github.com/gmlarumbe/tree-sitter-verilog"
+      :url "https://github.com/gmlarumbe/tree-sitter-systemverilog"
       :ext "\\.s?vh?\\'")
     ,(make-treesit-auto-recipe
       :lang 'vhdl


### PR DESCRIPTION
Current recipe points to legacy `gmlarumbe/tree-sitter-verilog` fork
whereas current `verilog-ts-mode` uses `gmlarumbe/tree-sitter-systemverilog`.