### PR TITLE
Set ABI 14 revision for C grammar

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -104,6 +104,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :remap 'c-mode
       :url "https://github.com/tree-sitter/tree-sitter-c"
       :requires 'cpp
+      :abi14-revision "v0.23.6"
       :ext "\\.c\\'")
     ,(make-treesit-auto-recipe
       :lang 'c-sharp


### PR DESCRIPTION
Set `:abi14-revision` to the most recent tag of https://github.com/tree-sitter/tree-sitter-c with ABI version 14. This should resolve https://github.com/renzmann/treesit-auto/issues/141 for C. 


```diff
~/src/tree-sitter-c $ git diff v0.23.6 v0.24.0 -- src/parser.c | grep -C3 LANGUAGE_VERSION
 #pragma GCC optimize ("O0")
 #endif

-#define LANGUAGE_VERSION 14
+#define LANGUAGE_VERSION 15
 #define STATE_COUNT 2015
 #define LARGE_STATE_COUNT 455
 #define SYMBOL_COUNT 360
```

I'm running Emacs 30.2.50 on Ubuntu 24.04.4 and this fixes the issue for me.

**Related PRs**
* https://github.com/renzmann/treesit-auto/pull/148
* https://github.com/renzmann/treesit-auto/pull/149
* https://github.com/renzmann/treesit-auto/pull/150