### PR TITLE
Set ABI 14 revision for Javascript grammar

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -242,6 +242,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :url "https://github.com/tree-sitter/tree-sitter-javascript"
       :revision "master"
       :source-dir "src"
+      :abi14-revision "v0.23.1"
       :ext "\\.js\\'")
     ,(make-treesit-auto-recipe
       :lang 'json


### PR DESCRIPTION
Set `:abi14-revision` to the most recent tag of https://github.com/tree-sitter/tree-sitter-javascript with ABI version 14. This should resolve https://github.com/renzmann/treesit-auto/issues/141 for Javascript.

```diff
~/src/tree-sitter-javascript $ git diff v0.23.1 v0.25.0  | grep -C3 "Tree-sitter ABI version"
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(TREE_SITTER_REUSE_ALLOCATOR "Reuse the library allocator" OFF)

-set(TREE_SITTER_ABI_VERSION 14 CACHE STRING "Tree-sitter ABI version")
+set(TREE_SITTER_ABI_VERSION 15 CACHE STRING "Tree-sitter ABI version")
 if(NOT ${TREE_SITTER_ABI_VERSION} MATCHES "^[0-9]+$")
     unset(TREE_SITTER_ABI_VERSION CACHE)
     message(FATAL_ERROR "TREE_SITTER_ABI_VERSION must be an integer")
``` 

**Related PRs**
* https://github.com/renzmann/treesit-auto/pull/148
* https://github.com/renzmann/treesit-auto/pull/149
* https://github.com/renzmann/treesit-auto/pull/150