### PR TITLE
Set ABI 14 revision for Rust grammar

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -347,6 +347,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'rust-ts-mode
       :remap 'rust-mode
       :url "https://github.com/tree-sitter/tree-sitter-rust"
+      :abi14-revision "v0.23.3"
       :ext "\\.rs\\'")
     ,(make-treesit-auto-recipe
       :lang 'scala


### PR DESCRIPTION
Set `:abi14-revision` to the most recent tag of https://github.com/tree-sitter/tree-sitter-rust with ABI version 14. This should resolve https://github.com/renzmann/treesit-auto/issues/141 for Rust.

```diff
~/src/tree-sitter-rust $ git diff v0.23.3 v0.24.0 | grep -C3 LANGUAGE_VERSION
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif

-#define LANGUAGE_VERSION 14
+#define LANGUAGE_VERSION 15
 #define STATE_COUNT 3823
 #define LARGE_STATE_COUNT 1063
 #define SYMBOL_COUNT 351
```

**Related PRs**
* https://github.com/renzmann/treesit-auto/pull/148
* https://github.com/renzmann/treesit-auto/pull/149
* https://github.com/renzmann/treesit-auto/pull/150