### PR TITLE
Missing ABI 14 revisions 

### DIFF
--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -103,6 +103,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'c-ts-mode
       :remap 'c-mode
       :url "https://github.com/tree-sitter/tree-sitter-c"
+      :abi14-revision "v0.23.6"
       :requires 'cpp
       :ext "\\.c\\'")
     ,(make-treesit-auto-recipe
@@ -142,12 +143,14 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :requires 'c
       :url "https://github.com/tree-sitter/tree-sitter-cpp"
       :revision "v0.22.0" ;; BUG: newer grammar breaks syntax highlighting in `c++-ts-mode'
+      :abi14-revision "v0.23.4"
       :ext "\\.cpp\\'")
     ,(make-treesit-auto-recipe
       :lang 'css
       :ts-mode 'css-ts-mode
       :remap 'css-mode
       :url "https://github.com/tree-sitter/tree-sitter-css"
+      :abi14-revision "v0.23.2"
       :ext "\\.css\\'")
     ,(make-treesit-auto-recipe
       :lang 'dart
@@ -241,6 +244,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :remap '(js-mode javascript-mode js2-mode)
       :url "https://github.com/tree-sitter/tree-sitter-javascript"
       :revision "master"
+      :abi14-revision "v0.23.1"
       :source-dir "src"
       :ext "\\.js\\'")
     ,(make-treesit-auto-recipe
@@ -347,6 +351,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'rust-ts-mode
       :remap 'rust-mode
       :url "https://github.com/tree-sitter/tree-sitter-rust"
+      :abi14-revision "v0.23.2"
       :ext "\\.rs\\'")
     ,(make-treesit-auto-recipe
       :lang 'scala
@@ -390,6 +395,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :requires 'typescript
       :url "https://github.com/tree-sitter/tree-sitter-typescript"
       :revision "master"
+      :abi14-revision "v0.20.3"
       :source-dir "tsx/src"
       :ext "\\.tsx\\'")
     ,(make-treesit-auto-recipe
@@ -399,6 +405,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :requires 'tsx
       :url "https://github.com/tree-sitter/tree-sitter-typescript"
       :revision "master"
+      :abi14-revision "v0.20.3"
       :source-dir "typescript/src"
       :ext "\\.ts\\'")
     ,(make-treesit-auto-recipe

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -582,7 +582,7 @@ Non-nil only if installation completed without any errors."
   "Return the revision for recipe, potentially using abi14-revision."
   (let ((default-revision (treesit-auto-recipe-revision recipe)))
     (if (and (fboundp 'treesit-library-abi-version) (eq (treesit-library-abi-version) 14))
-	(or (treesit-auto-recipe-abi14-revision recipe) default-revision)
+        (or (treesit-auto-recipe-abi14-revision recipe) default-revision)
       default-revision)))
 
 (defun treesit-auto-install-all ()

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -383,6 +383,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :remap 'sql-mode
       :revision "gh-pages"
       :url "https://github.com/DerekStride/tree-sitter-sql"
+      :source-dir "src"
       :ext "\\.sql\\'")
     ,(make-treesit-auto-recipe
       :lang 'surface

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -111,6 +111,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'csharp-ts-mode
       :remap 'csharp-mode
       :url "https://github.com/tree-sitter/tree-sitter-c-sharp"
+      :abi14-revision "v0.23.1"
       :ext "\\.cs\\'")
     ,(make-treesit-auto-recipe
       :lang 'clojure
@@ -174,6 +175,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :lang 'gitcommit
       :ts-mode 'git-commit-ts-mode
       :url "https://github.com/gbprod/tree-sitter-gitcommit"
+      :abi14-revision "v0.4.0"
       :ext "\\COMMIT_EDITMSG\\'")
     ,(make-treesit-auto-recipe
       :lang 'glsl
@@ -213,6 +215,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'heex-ts-mode
       :remap 'heex-mode
       :url "https://github.com/phoenixframework/tree-sitter-heex"
+      :abi14-revision "v0.8.1"
       :ext "\\.heex\\'")
     ,(make-treesit-auto-recipe
       :lang 'html
@@ -224,6 +227,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :lang 'hyprlang
       :ts-mode 'hyprlang-ts-mode
       :url "https://github.com/tree-sitter-grammars/tree-sitter-hyprlang"
+      :abi14-revision "v3.0.0"
       :ext "/hypr/.*\\.conf\\'")
     ,(make-treesit-auto-recipe
       :lang 'janet-simple
@@ -257,6 +261,7 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'julia-ts-mode
       :remap 'julia-mode
       :url "https://github.com/tree-sitter/tree-sitter-julia"
+      :abi14-revision "v0.23.1"
       :ext "\\.jl\\'")
     ,(make-treesit-auto-recipe
       :lang 'kotlin
@@ -269,24 +274,28 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'lua-ts-mode
       :remap 'lua-mode
       :url "https://github.com/tree-sitter-grammars/tree-sitter-lua"
+      :abi14-revision "v0.3.0"
       :ext "\\.lua\\'")
     ,(make-treesit-auto-recipe
       :lang 'magik
       :ts-mode 'magik-ts-mode
       :remap 'magik-mode
       :url "https://github.com/krn-robin/tree-sitter-magik"
+      :abi14-revision "0.0.1"
       :ext "\\.magik\\'")
     ,(make-treesit-auto-recipe
       :lang 'make
       :ts-mode 'makefile-ts-mode
       :remap 'makefile-mode
       :url "https://github.com/tree-sitter-grammars/tree-sitter-make"
+      :abi14-revision "v1.1.1"
       :ext "\\([Mm]akefile\\|.*\\.\\(mk\\|make\\)\\)\\'")
     ,(make-treesit-auto-recipe
       :lang 'markdown
       :ts-mode 'markdown-ts-mode
       :remap '(poly-markdown-mode markdown-mode)
       :url "https://github.com/tree-sitter-grammars/tree-sitter-markdown"
+      :abi14-revision "v0.4.1"
       :source-dir "tree-sitter-markdown/src"
       :ext "\\.md\\'")
     ,(make-treesit-auto-recipe
@@ -312,12 +321,14 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'perl-ts-mode
       :remap 'perl-mode
       :url "https://github.com/ganezdragon/tree-sitter-perl"
+      :abi14-revision "v1.1.1"
       :ext "\\.pl\\'")
     ,(make-treesit-auto-recipe
       :lang 'php
       :ts-mode 'php-ts-mode
       :remap 'php-mode
       :url "https://github.com/tree-sitter/tree-sitter-php"
+      :abi14-revision "v0.23.9"
       :source-dir "php/src"
       :ext "\\.php\\'")
     ,(make-treesit-auto-recipe
@@ -357,12 +368,14 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :ts-mode 'scala-ts-mode
       :remap 'scala-mode
       :url "https://github.com/tree-sitter/tree-sitter-scala"
+      :abi14-revision "v0.24.1"
       :ext "\\.\\(scala\\|sbt\\)\\'")
     ,(make-treesit-auto-recipe
       :lang 'solidity
       :ts-mode 'solidity-ts-mode
       :remap 'solidity-mode
       :url "https://github.com/JoranHonig/tree-sitter-solidity"
+      :abi14-revision "v1.2.9"
       :ext "\\.sol\\'")
     ,(make-treesit-auto-recipe
       :lang 'sql

--- a/treesit-auto.el
+++ b/treesit-auto.el
@@ -142,7 +142,6 @@ by manipulating the `treesit-auto-recipe-list' variable."
       :remap 'c++-mode
       :requires 'c
       :url "https://github.com/tree-sitter/tree-sitter-cpp"
-      :revision "v0.22.0" ;; BUG: newer grammar breaks syntax highlighting in `c++-ts-mode'
       :abi14-revision "v0.23.4"
       :ext "\\.cpp\\'")
     ,(make-treesit-auto-recipe


### PR DESCRIPTION
**Recipes updated with ABI 14 revisions for grammars:**
c, c++, rust, javascript, typescript, tsx, php, css, c-sharp, scala, julia, lua, perl, make, markdown, gitcommit, heex, hyprlang, magik, solidity.